### PR TITLE
Better Errors

### DIFF
--- a/ingest-delete/package-lock.json
+++ b/ingest-delete/package-lock.json
@@ -22,6 +22,21 @@
                 "undici": "^5.20.0"
             }
         },
+        "node_modules/@aws-crypto/crc32": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+            "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+            "dependencies": {
+                "@aws-crypto/util": "^3.0.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
         "node_modules/@aws-crypto/ie11-detection": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
@@ -99,11 +114,11 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/abort-controller": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.329.0.tgz",
-            "integrity": "sha512-hzrjPNQcJoSPe0oS20V5i98oiEZSM3mKNiR6P3xHTHTPI/F23lyjGZ+/CSkCmJbSWfGZ5sHZZcU6AWuS7xBdTw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+            "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -111,46 +126,47 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudformation": {
-            "version": "3.332.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.332.0.tgz",
-            "integrity": "sha512-Y6B3fSk62TOYTV78EpBSHaXW1BPnRpZfG/DDdDkBo/H9kGTetuFSqNddUyRIdlU6UQV1mJS61ZlZdPyNqbvHvw==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.348.0.tgz",
+            "integrity": "sha512-F1WLJhJWMjzzmxuRfXMnPIT0UkOSGZSMBDkcIt3Jn275H8G1uY/sK/XFUDZEKSwiduo1dNhMhZDMURLOEr4N8g==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.332.0",
-                "@aws-sdk/config-resolver": "3.329.0",
-                "@aws-sdk/credential-provider-node": "3.332.0",
-                "@aws-sdk/fetch-http-handler": "3.329.0",
-                "@aws-sdk/hash-node": "3.329.0",
-                "@aws-sdk/invalid-dependency": "3.329.0",
-                "@aws-sdk/middleware-content-length": "3.329.0",
-                "@aws-sdk/middleware-endpoint": "3.329.0",
-                "@aws-sdk/middleware-host-header": "3.329.0",
-                "@aws-sdk/middleware-logger": "3.329.0",
-                "@aws-sdk/middleware-recursion-detection": "3.329.0",
-                "@aws-sdk/middleware-retry": "3.329.0",
-                "@aws-sdk/middleware-serde": "3.329.0",
-                "@aws-sdk/middleware-signing": "3.329.0",
-                "@aws-sdk/middleware-stack": "3.329.0",
-                "@aws-sdk/middleware-user-agent": "3.332.0",
-                "@aws-sdk/node-config-provider": "3.329.0",
-                "@aws-sdk/node-http-handler": "3.329.0",
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/smithy-client": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
-                "@aws-sdk/url-parser": "3.329.0",
+                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-                "@aws-sdk/util-defaults-mode-node": "3.329.0",
-                "@aws-sdk/util-endpoints": "3.332.0",
-                "@aws-sdk/util-retry": "3.329.0",
-                "@aws-sdk/util-user-agent-browser": "3.329.0",
-                "@aws-sdk/util-user-agent-node": "3.329.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
-                "@aws-sdk/util-waiter": "3.329.0",
-                "fast-xml-parser": "4.1.2",
+                "@aws-sdk/util-waiter": "3.347.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
+                "fast-xml-parser": "4.2.4",
                 "tslib": "^2.5.0",
                 "uuid": "^8.3.2"
             },
@@ -159,46 +175,47 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudwatch": {
-            "version": "3.332.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.332.0.tgz",
-            "integrity": "sha512-eskCIHKQ862KzC+4BiuUEZZXs2TmoAgTJ6WDOfnf9GcyqVn4/YdhZfZzPADjVE6LqkQfYwR+tvOHOqeQSSyc1Q==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.348.0.tgz",
+            "integrity": "sha512-UCtX/hMfaJiMx6LotQxUwdV4REgOuV3HVOy8k3NDaDkCSw4z1KCx5YYJRDdIkD88tucF0GpFun20eM4ekkgNCA==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.332.0",
-                "@aws-sdk/config-resolver": "3.329.0",
-                "@aws-sdk/credential-provider-node": "3.332.0",
-                "@aws-sdk/fetch-http-handler": "3.329.0",
-                "@aws-sdk/hash-node": "3.329.0",
-                "@aws-sdk/invalid-dependency": "3.329.0",
-                "@aws-sdk/middleware-content-length": "3.329.0",
-                "@aws-sdk/middleware-endpoint": "3.329.0",
-                "@aws-sdk/middleware-host-header": "3.329.0",
-                "@aws-sdk/middleware-logger": "3.329.0",
-                "@aws-sdk/middleware-recursion-detection": "3.329.0",
-                "@aws-sdk/middleware-retry": "3.329.0",
-                "@aws-sdk/middleware-serde": "3.329.0",
-                "@aws-sdk/middleware-signing": "3.329.0",
-                "@aws-sdk/middleware-stack": "3.329.0",
-                "@aws-sdk/middleware-user-agent": "3.332.0",
-                "@aws-sdk/node-config-provider": "3.329.0",
-                "@aws-sdk/node-http-handler": "3.329.0",
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/smithy-client": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
-                "@aws-sdk/url-parser": "3.329.0",
+                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-                "@aws-sdk/util-defaults-mode-node": "3.329.0",
-                "@aws-sdk/util-endpoints": "3.332.0",
-                "@aws-sdk/util-retry": "3.329.0",
-                "@aws-sdk/util-user-agent-browser": "3.329.0",
-                "@aws-sdk/util-user-agent-node": "3.329.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
-                "@aws-sdk/util-waiter": "3.329.0",
-                "fast-xml-parser": "4.1.2",
+                "@aws-sdk/util-waiter": "3.347.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
+                "fast-xml-parser": "4.2.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -206,45 +223,46 @@
             }
         },
         "node_modules/@aws-sdk/client-ssm": {
-            "version": "3.332.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.332.0.tgz",
-            "integrity": "sha512-SHcbs2XHTUwHNj4LU9zwyrpyZOSv4MNUMI4o5aBTwDQ7TfCAg9KBxLEDsLoMj7+MSnPTcedjdXhGZwrnrAKXcg==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.348.0.tgz",
+            "integrity": "sha512-zqT7quggsJjOlhxl5D7JDNA9ufi0L9YqyHk3WygMCTjcuaaKLJJP1mVAHm2Ia3LvW3Vj4AdoXt0Tm2LmV0+cSQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.332.0",
-                "@aws-sdk/config-resolver": "3.329.0",
-                "@aws-sdk/credential-provider-node": "3.332.0",
-                "@aws-sdk/fetch-http-handler": "3.329.0",
-                "@aws-sdk/hash-node": "3.329.0",
-                "@aws-sdk/invalid-dependency": "3.329.0",
-                "@aws-sdk/middleware-content-length": "3.329.0",
-                "@aws-sdk/middleware-endpoint": "3.329.0",
-                "@aws-sdk/middleware-host-header": "3.329.0",
-                "@aws-sdk/middleware-logger": "3.329.0",
-                "@aws-sdk/middleware-recursion-detection": "3.329.0",
-                "@aws-sdk/middleware-retry": "3.329.0",
-                "@aws-sdk/middleware-serde": "3.329.0",
-                "@aws-sdk/middleware-signing": "3.329.0",
-                "@aws-sdk/middleware-stack": "3.329.0",
-                "@aws-sdk/middleware-user-agent": "3.332.0",
-                "@aws-sdk/node-config-provider": "3.329.0",
-                "@aws-sdk/node-http-handler": "3.329.0",
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/smithy-client": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
-                "@aws-sdk/url-parser": "3.329.0",
+                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-                "@aws-sdk/util-defaults-mode-node": "3.329.0",
-                "@aws-sdk/util-endpoints": "3.332.0",
-                "@aws-sdk/util-retry": "3.329.0",
-                "@aws-sdk/util-user-agent-browser": "3.329.0",
-                "@aws-sdk/util-user-agent-node": "3.329.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
-                "@aws-sdk/util-waiter": "3.329.0",
+                "@aws-sdk/util-waiter": "3.347.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
                 "tslib": "^2.5.0",
                 "uuid": "^8.3.2"
             },
@@ -253,41 +271,42 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.332.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.332.0.tgz",
-            "integrity": "sha512-4q1Nko8M6YVANdEiLYvdv1qb00j4xN4ppE/6d4xpGp7DxHYlm0GA762h0/TR2dun+2I+SMnwj4Fv6BxOmzBaEw==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.348.0.tgz",
+            "integrity": "sha512-5S23gVKBl0fhZ96RD8LdPhMKeh8E5fmebyZxMNZuWliSXz++Q9ZCrwPwQbkks3duPOTcKKobs3IoqP82HoXMvQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.329.0",
-                "@aws-sdk/fetch-http-handler": "3.329.0",
-                "@aws-sdk/hash-node": "3.329.0",
-                "@aws-sdk/invalid-dependency": "3.329.0",
-                "@aws-sdk/middleware-content-length": "3.329.0",
-                "@aws-sdk/middleware-endpoint": "3.329.0",
-                "@aws-sdk/middleware-host-header": "3.329.0",
-                "@aws-sdk/middleware-logger": "3.329.0",
-                "@aws-sdk/middleware-recursion-detection": "3.329.0",
-                "@aws-sdk/middleware-retry": "3.329.0",
-                "@aws-sdk/middleware-serde": "3.329.0",
-                "@aws-sdk/middleware-stack": "3.329.0",
-                "@aws-sdk/middleware-user-agent": "3.332.0",
-                "@aws-sdk/node-config-provider": "3.329.0",
-                "@aws-sdk/node-http-handler": "3.329.0",
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/smithy-client": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
-                "@aws-sdk/url-parser": "3.329.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-                "@aws-sdk/util-defaults-mode-node": "3.329.0",
-                "@aws-sdk/util-endpoints": "3.332.0",
-                "@aws-sdk/util-retry": "3.329.0",
-                "@aws-sdk/util-user-agent-browser": "3.329.0",
-                "@aws-sdk/util-user-agent-node": "3.329.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -295,41 +314,42 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.332.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.332.0.tgz",
-            "integrity": "sha512-tz8k8Yqm4TScIfit0Tum2zWAq1md+gZKr747CSixd4Zwcp7Vwh75cRoL7Rz1ZHSEn1Yo983MWREevVez3SubLw==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.348.0.tgz",
+            "integrity": "sha512-tvHpcycx4EALvk38I9rAOdPeHvBDezqIB4lrE7AvnOJljlvCcdQ2gXa9GDrwrM7zuYBIZMBRE/njTMrCwoOdAA==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.329.0",
-                "@aws-sdk/fetch-http-handler": "3.329.0",
-                "@aws-sdk/hash-node": "3.329.0",
-                "@aws-sdk/invalid-dependency": "3.329.0",
-                "@aws-sdk/middleware-content-length": "3.329.0",
-                "@aws-sdk/middleware-endpoint": "3.329.0",
-                "@aws-sdk/middleware-host-header": "3.329.0",
-                "@aws-sdk/middleware-logger": "3.329.0",
-                "@aws-sdk/middleware-recursion-detection": "3.329.0",
-                "@aws-sdk/middleware-retry": "3.329.0",
-                "@aws-sdk/middleware-serde": "3.329.0",
-                "@aws-sdk/middleware-stack": "3.329.0",
-                "@aws-sdk/middleware-user-agent": "3.332.0",
-                "@aws-sdk/node-config-provider": "3.329.0",
-                "@aws-sdk/node-http-handler": "3.329.0",
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/smithy-client": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
-                "@aws-sdk/url-parser": "3.329.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-                "@aws-sdk/util-defaults-mode-node": "3.329.0",
-                "@aws-sdk/util-endpoints": "3.332.0",
-                "@aws-sdk/util-retry": "3.329.0",
-                "@aws-sdk/util-user-agent-browser": "3.329.0",
-                "@aws-sdk/util-user-agent-node": "3.329.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -337,45 +357,46 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.332.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.332.0.tgz",
-            "integrity": "sha512-uVobnXIzMcEhwBDyk6iOt36N/TRNI8hwq7MQugjYGj7Inma9g4vnR09hXJ24HxyKCoVUoIgMbEguQ43+/+uvDQ==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.348.0.tgz",
+            "integrity": "sha512-4iaQlWAOHMEF4xjR/FB/ws3aUjXjJHwbsIcqbdYAxsKijDYYTZYCPc/gM0NE1yi28qlNYNhMzHipe5xTYbU2Eg==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.329.0",
-                "@aws-sdk/credential-provider-node": "3.332.0",
-                "@aws-sdk/fetch-http-handler": "3.329.0",
-                "@aws-sdk/hash-node": "3.329.0",
-                "@aws-sdk/invalid-dependency": "3.329.0",
-                "@aws-sdk/middleware-content-length": "3.329.0",
-                "@aws-sdk/middleware-endpoint": "3.329.0",
-                "@aws-sdk/middleware-host-header": "3.329.0",
-                "@aws-sdk/middleware-logger": "3.329.0",
-                "@aws-sdk/middleware-recursion-detection": "3.329.0",
-                "@aws-sdk/middleware-retry": "3.329.0",
-                "@aws-sdk/middleware-sdk-sts": "3.329.0",
-                "@aws-sdk/middleware-serde": "3.329.0",
-                "@aws-sdk/middleware-signing": "3.329.0",
-                "@aws-sdk/middleware-stack": "3.329.0",
-                "@aws-sdk/middleware-user-agent": "3.332.0",
-                "@aws-sdk/node-config-provider": "3.329.0",
-                "@aws-sdk/node-http-handler": "3.329.0",
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/smithy-client": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
-                "@aws-sdk/url-parser": "3.329.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-sdk-sts": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-                "@aws-sdk/util-defaults-mode-node": "3.329.0",
-                "@aws-sdk/util-endpoints": "3.332.0",
-                "@aws-sdk/util-retry": "3.329.0",
-                "@aws-sdk/util-user-agent-browser": "3.329.0",
-                "@aws-sdk/util-user-agent-node": "3.329.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
-                "fast-xml-parser": "4.1.2",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
+                "fast-xml-parser": "4.2.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -383,13 +404,13 @@
             }
         },
         "node_modules/@aws-sdk/config-resolver": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.329.0.tgz",
-            "integrity": "sha512-Oj6eiT3q+Jn685yvUrfRi8PhB3fb81hasJqdrsEivA8IP8qAgnVUTJzXsh8O2UX8UM2MF6A1gTgToSgneJuw2Q==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
+            "integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
             "dependencies": {
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-config-provider": "3.310.0",
-                "@aws-sdk/util-middleware": "3.329.0",
+                "@aws-sdk/util-middleware": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -397,12 +418,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.329.0.tgz",
-            "integrity": "sha512-B4orC9hMt9hG82vAR0TAnQqjk6cFDbO2S14RdzUj2n2NPlGWW4Blkv3NTo86K0lq011VRhtqaLcuTwn5EJD5Sg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
+            "integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -410,14 +431,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-imds": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.329.0.tgz",
-            "integrity": "sha512-ggPlnd7QROPTid0CwT01TYYGvstRRTpzTGsQ/B31wkh30IrRXE81W3S4xrOYuqQD3u0RnflSxnvhs+EayJEYjg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
+            "integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
             "dependencies": {
-                "@aws-sdk/node-config-provider": "3.329.0",
-                "@aws-sdk/property-provider": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
-                "@aws-sdk/url-parser": "3.329.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -425,18 +446,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.332.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.332.0.tgz",
-            "integrity": "sha512-DTW6d6rcqizPVyvcIrwvxecQ7e5GONtVc5Wyf0RTfqf41sDOVZYmn6G+zEFSpBLW0975uZbJS0lyLWtJe2VujQ==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.348.0.tgz",
+            "integrity": "sha512-0IEH5mH/cz2iLyr/+pSa3sCsQcGADiLSEn6yivsXdfz1zDqBiv+ffDoL0+Pvnp+TKf8sA6OlX8PgoMoEBvBdKw==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.329.0",
-                "@aws-sdk/credential-provider-imds": "3.329.0",
-                "@aws-sdk/credential-provider-process": "3.329.0",
-                "@aws-sdk/credential-provider-sso": "3.332.0",
-                "@aws-sdk/credential-provider-web-identity": "3.329.0",
-                "@aws-sdk/property-provider": "3.329.0",
-                "@aws-sdk/shared-ini-file-loader": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/credential-provider-env": "3.347.0",
+                "@aws-sdk/credential-provider-imds": "3.347.0",
+                "@aws-sdk/credential-provider-process": "3.347.0",
+                "@aws-sdk/credential-provider-sso": "3.348.0",
+                "@aws-sdk/credential-provider-web-identity": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -444,19 +465,19 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.332.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.332.0.tgz",
-            "integrity": "sha512-KkBayS9k4WyJTvC86ngeRM+RmWxNCS1BHvudkR6PLXfnsNPDzxySDVY0UgxVhbNYDYsO561fXZt9ccpKyVWjgg==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.348.0.tgz",
+            "integrity": "sha512-ngRWphm9e36i58KqVi7Z8WOub+k0cSl+JZaAmgfFm0+dsfBG5uheo598OeiwWV0DqlilvaQZFaMVQgG2SX/tHg==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.329.0",
-                "@aws-sdk/credential-provider-imds": "3.329.0",
-                "@aws-sdk/credential-provider-ini": "3.332.0",
-                "@aws-sdk/credential-provider-process": "3.329.0",
-                "@aws-sdk/credential-provider-sso": "3.332.0",
-                "@aws-sdk/credential-provider-web-identity": "3.329.0",
-                "@aws-sdk/property-provider": "3.329.0",
-                "@aws-sdk/shared-ini-file-loader": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/credential-provider-env": "3.347.0",
+                "@aws-sdk/credential-provider-imds": "3.347.0",
+                "@aws-sdk/credential-provider-ini": "3.348.0",
+                "@aws-sdk/credential-provider-process": "3.347.0",
+                "@aws-sdk/credential-provider-sso": "3.348.0",
+                "@aws-sdk/credential-provider-web-identity": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -464,13 +485,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.329.0.tgz",
-            "integrity": "sha512-5oO220qoFc2pMdZDQa6XN/mVhp669I3+LqMbbscGtX/UgLJPSOb7YzPld9Wjv12L5rf+sD3G1PF3LZXO0vKLFA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
+            "integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.329.0",
-                "@aws-sdk/shared-ini-file-loader": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -478,15 +499,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.332.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.332.0.tgz",
-            "integrity": "sha512-SaKXl48af3n6LRitcaEqbeg1YDXwQ0A5QziC1xQyYPraEIj3IZ/GyTjx04Lo2jxNYHuEOE8u4aTw1+IK1GDKbg==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.348.0.tgz",
+            "integrity": "sha512-5cQao705376KgGkLv9xgkQ3T5H7KdNddWuyoH2wDcrHd1BA2Lnrell3Yyh7R6jQeV7uCQE/z0ugUOKhDqNKIqQ==",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.332.0",
-                "@aws-sdk/property-provider": "3.329.0",
-                "@aws-sdk/shared-ini-file-loader": "3.329.0",
-                "@aws-sdk/token-providers": "3.332.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/client-sso": "3.348.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/token-providers": "3.348.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -494,36 +515,47 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.329.0.tgz",
-            "integrity": "sha512-lcEibZD7AlutCacpQ6DyNUqElZJDq+ylaIo5a8MH9jGh7Pg2WpDg0Sy+B6FbGCkVn4eIjdHxeX54JM245nhESg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
+            "integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/fetch-http-handler": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.329.0.tgz",
-            "integrity": "sha512-9jfIeJhYCcTX4ScXOueRTB3S/tVce0bRsKxKDP0PnTxnGYOwKXoM9lAPmiYItzYmQ/+QzjTI8xfkA9Usz2SK/Q==",
+        "node_modules/@aws-sdk/eventstream-codec": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+            "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/querystring-builder": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-crypto/crc32": "3.0.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-hex-encoding": "3.310.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/fetch-http-handler": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
+            "integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/querystring-builder": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/hash-node": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.329.0.tgz",
-            "integrity": "sha512-6RmnWXNWpi7yAs0oRDQlkMn2wfXOStr/8kTCgiAiqrk1KopGSBkC2veKiKRSfv02FTd1yV/ISqYNIRqW1VLyxg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+            "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
             "dependencies": {
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-buffer-from": "3.310.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
@@ -533,11 +565,11 @@
             }
         },
         "node_modules/@aws-sdk/invalid-dependency": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.329.0.tgz",
-            "integrity": "sha512-UXynGusDxN/HxLma5ByJ7u+XnuMd47NbHOjJgYsaAjb1CVZT7hEPXOB+mcZ+Ku7To5SCOKu2QbRn7m4bGespBg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+            "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             }
         },
@@ -553,12 +585,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-content-length": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.329.0.tgz",
-            "integrity": "sha512-7kCd+CvY/4KbyXB0uyL7jCwPjMi2yERMALFdEH9dsUciwmxIQT6eSc4aF6wImC4UrbafaqmXvvHErABKMVBTKA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+            "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -566,14 +598,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-endpoint": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.329.0.tgz",
-            "integrity": "sha512-hdJRoNdCM0BT4W+rrtee+kfFRgGPGXQDgtbIQlf/FuuuYz2sdef7/SYWr0mxuncnVBW5WkYSPP8h6q07whSKbg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+            "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
             "dependencies": {
-                "@aws-sdk/middleware-serde": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
-                "@aws-sdk/url-parser": "3.329.0",
-                "@aws-sdk/util-middleware": "3.329.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
+                "@aws-sdk/util-middleware": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -581,12 +613,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.329.0.tgz",
-            "integrity": "sha512-JrHeUdTIpTCfXDo9JpbAbZTS1x4mt63CCytJRq0mpWp+FlP9hjckBcNxWdR/wSKEzP9pDRnTri638BOwWH7O8w==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+            "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -594,11 +626,11 @@
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.329.0.tgz",
-            "integrity": "sha512-lKeeTXsYC1NiwmxrXsZepcwNXPoQxTNNbeD1qaCELPGK2cJlrGoeAP2YRWzpwO2kNZWrDLaGAPT/EUEhqw+d1w==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+            "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
             "dependencies": {
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -606,12 +638,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.329.0.tgz",
-            "integrity": "sha512-0/TYOJwrj1Z8s+Y7thibD23hggBq/K/01NwPk32CwWG/G+1vWozs5DefknEl++w0vuV+39pkY4KHI8m/+wOCpg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+            "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -619,15 +651,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-retry": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.329.0.tgz",
-            "integrity": "sha512-cB3D7GlhHUcHGOlygOYxD9cPhwsTYEAMcohK38An8+RHNp6VQEWezzLFCmHVKUSeCQ+wkjZfPA40jOG0rbjSgQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
+            "integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/service-error-classification": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
-                "@aws-sdk/util-middleware": "3.329.0",
-                "@aws-sdk/util-retry": "3.329.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/service-error-classification": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-middleware": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
                 "tslib": "^2.5.0",
                 "uuid": "^8.3.2"
             },
@@ -636,12 +668,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-sts": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.329.0.tgz",
-            "integrity": "sha512-bqtZuhkH8pANb2Gb4FEM1p27o+BoDBmVhEWm8sWH+APsyOor3jc6eUG2GxkfoO6D5tGNIuyCC/GuvW9XDIe4Kg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
+            "integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
             "dependencies": {
-                "@aws-sdk/middleware-signing": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -649,11 +681,11 @@
             }
         },
         "node_modules/@aws-sdk/middleware-serde": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.329.0.tgz",
-            "integrity": "sha512-tvM9NdPuRPCozPjTGNOeYZeLlyx3BcEyajrkRorCRf1YzG/mXdB6I1stote7i4q1doFtYTz0sYL8bqW3LUPn9A==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+            "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
             "dependencies": {
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -661,15 +693,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.329.0.tgz",
-            "integrity": "sha512-bL1nI+EUcF5B1ipwDXxiKL+Uw02Mbt/TNX54PbzunBGZIyO6DZG/H+M3U296bYbvPlwlZhp26O830g6K7VEWsA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
+            "integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.329.0",
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/signature-v4": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
-                "@aws-sdk/util-middleware": "3.329.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/signature-v4": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-middleware": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -677,9 +709,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-stack": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.329.0.tgz",
-            "integrity": "sha512-2huFLhJ45td2nuiIOjpc9JKJbFNn5CYmw9U8YDITTcydpteRN62CzCpeqroDvF89VOLWxh0ZFtuLCGUr7liSWQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+            "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -688,13 +720,13 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.332.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.332.0.tgz",
-            "integrity": "sha512-rSL1xP4QmcMOsunN1p5ZDR9GT3vvoSCnYa4iPvMSjP8Jx7l4ff/aVctwfZkMs/up12+68Jqwj4TvtaCvCFXdUA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.347.0.tgz",
+            "integrity": "sha512-wJbGN3OE1/daVCrwk49whhIr9E0j1N4gWwN/wi4WuyYIA+5lMUfVp0aGIOvZR+878DxuFz2hQ4XcZVT4K2WvQw==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
-                "@aws-sdk/util-endpoints": "3.332.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -702,13 +734,13 @@
             }
         },
         "node_modules/@aws-sdk/node-config-provider": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.329.0.tgz",
-            "integrity": "sha512-hg9rGNlkzh8aeR/sQbijrkFx2BIO53j4Z6qDxPNWwSGpl05jri1VHxHx2HZMwgbY6Zy/DSguETN/BL8vdFqyLg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
+            "integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.329.0",
-                "@aws-sdk/shared-ini-file-loader": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -716,14 +748,14 @@
             }
         },
         "node_modules/@aws-sdk/node-http-handler": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.329.0.tgz",
-            "integrity": "sha512-OrjaHjU2ZTPfoHa5DruRvTIbeHH/cc0wvh4ml+FwDpWaPaBpOhLiluhZ3anqX1l5QjrXNiQnL8FxSM5OV/zVCA==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.348.0.tgz",
+            "integrity": "sha512-wxdgc4tO5F6lN4wHr0CZ4TyIjDW/ORp4SJZdWYNs2L5J7+/SwqgJY2lxRlGi0i7Md+apAdE3sT3ukVQ/9pVfPg==",
             "dependencies": {
-                "@aws-sdk/abort-controller": "3.329.0",
-                "@aws-sdk/protocol-http": "3.329.0",
-                "@aws-sdk/querystring-builder": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/abort-controller": "3.347.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/querystring-builder": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -731,11 +763,11 @@
             }
         },
         "node_modules/@aws-sdk/property-provider": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.329.0.tgz",
-            "integrity": "sha512-1cHLTV6yyMGaMSWWDW/p4vTkJ1cc5BOEO+A0eHuAcoSOk+LDe9IKhUG3/ZOvvYKQYcqIj5jjGSni/noXNCl/qw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
+            "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
             "dependencies": {
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -743,11 +775,11 @@
             }
         },
         "node_modules/@aws-sdk/protocol-http": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.329.0.tgz",
-            "integrity": "sha512-0rLEHY6QTHTUUcVxzGbPUSmCKlXWplxT/fcYRh0bcc5MBK4naKfcQft1O6Ajp8uqs/9YPZ7XCVCn90pDeJfeaw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
             "dependencies": {
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -755,11 +787,11 @@
             }
         },
         "node_modules/@aws-sdk/querystring-builder": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.329.0.tgz",
-            "integrity": "sha512-UWgMKkS5trliaDJG4nPv3onu8Y0aBuwRo7RdIgggguOiU8pU6pq1I113nH2FBNWy+Me1bwf+bcviJh0pCo6bEg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+            "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
             "dependencies": {
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-uri-escape": "3.310.0",
                 "tslib": "^2.5.0"
             },
@@ -768,11 +800,11 @@
             }
         },
         "node_modules/@aws-sdk/querystring-parser": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.329.0.tgz",
-            "integrity": "sha512-9mkK+FB7snJ2G7H3CqtprDwYIRhzm6jEezffCwUWrC+lbqHBbErbhE9IeU/MKxILmf0RbC2riXEY1MHGspjRrQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+            "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
             "dependencies": {
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -780,19 +812,19 @@
             }
         },
         "node_modules/@aws-sdk/service-error-classification": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.329.0.tgz",
-            "integrity": "sha512-TSNr0flOcCLe71aPp7MjblKNGsmxpTU4xR5772MDX9Cz9GUTNZCPFtvrcqd+wzEPP/AC7XwNXe8KjoXooZImUQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+            "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/shared-ini-file-loader": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.329.0.tgz",
-            "integrity": "sha512-e0hyd75fbjMd4aCoRwpP2/HR+0oScwogErVArIkq3F42c/hyNCQP3sph4JImuXIjuo6HNnpKpf20CEPPhNna8A==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
+            "integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
             "dependencies": {
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -800,14 +832,15 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.329.0.tgz",
-            "integrity": "sha512-9EnLoyOD5nFtCRAp+QRllDgQASCfY7jLHVhwht7jzwE80wE65Z9Ym5Z/mwTd4IyTz/xXfCvcE2VwClsBt0Ybdw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
+            "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
             "dependencies": {
+                "@aws-sdk/eventstream-codec": "3.347.0",
                 "@aws-sdk/is-array-buffer": "3.310.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-middleware": "3.329.0",
+                "@aws-sdk/util-middleware": "3.347.0",
                 "@aws-sdk/util-uri-escape": "3.310.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
@@ -817,12 +850,12 @@
             }
         },
         "node_modules/@aws-sdk/smithy-client": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.329.0.tgz",
-            "integrity": "sha512-7E0fGpBKxwFqHHAOqNbgNsHSEmCZLuvmU9yvG9DXKVzrS4P48O/PfOro123WpcFZs3STyOVgH8wjUPftHAVKmg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+            "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
             "dependencies": {
-                "@aws-sdk/middleware-stack": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -830,14 +863,14 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.332.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.332.0.tgz",
-            "integrity": "sha512-fccbg6OSl0l658pxl2p1MoU9gEePo5B361+JNaN0zfRMu7c5HBXCpdl4djlFxAHjltrX9f1+BKqfGHYgI3h8SQ==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.348.0.tgz",
+            "integrity": "sha512-nTjoJkUsJUrJTZuqaeMD9PW2//Rdg2HgfDjiyC4jmAXtayWYCi11mqauurMaUHJ3p5qJ8f5xzxm6vBTbrftPag==",
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.332.0",
-                "@aws-sdk/property-provider": "3.329.0",
-                "@aws-sdk/shared-ini-file-loader": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/client-sso-oidc": "3.348.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -845,9 +878,9 @@
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.329.0.tgz",
-            "integrity": "sha512-wFBW4yciDfzQBSFmWNaEvHShnSGLMxSu9Lls6EUf6xDMavxSB36bsrVRX6CyAo/W0NeIIyEOW1LclGPgJV1okg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -856,12 +889,12 @@
             }
         },
         "node_modules/@aws-sdk/url-parser": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.329.0.tgz",
-            "integrity": "sha512-/VcfL7vNJKJGSjYYHVQF3bYCDFs4fSzB7j5qeVDwRdWr870gE7O1Dar+sLWBRKFF3AX+4VzplqzUfpu9t44JVA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+            "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
             "dependencies": {
-                "@aws-sdk/querystring-parser": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/querystring-parser": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             }
         },
@@ -920,12 +953,12 @@
             }
         },
         "node_modules/@aws-sdk/util-defaults-mode-browser": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.329.0.tgz",
-            "integrity": "sha512-2iSiy/pzX3OXMhtSxtAzOiEFr3viQEFnYOTeZuiheuyS+cea2L79F6SlZ1110b/nOIU/UOrxxtz83HVad8YFMQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
+            "integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             },
@@ -934,15 +967,15 @@
             }
         },
         "node_modules/@aws-sdk/util-defaults-mode-node": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.329.0.tgz",
-            "integrity": "sha512-7A6C7YKjkZtmKtH29isYEtOCbhd7IcXPP8lftN8WAWlLOiZE4gV7PHveagUj7QserJzgRKGwwTQbBj53n18HYg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
+            "integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
             "dependencies": {
-                "@aws-sdk/config-resolver": "3.329.0",
-                "@aws-sdk/credential-provider-imds": "3.329.0",
-                "@aws-sdk/node-config-provider": "3.329.0",
-                "@aws-sdk/property-provider": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-imds": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -950,11 +983,11 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.332.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.332.0.tgz",
-            "integrity": "sha512-nQx7AiOroMU2hj6h+umWOSZ+WECwxupaxFUK/PPKGW6NY/VdQE6LluYnXOtF5awlr8w1nPksT0Lq05PZutMDLA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.347.0.tgz",
+            "integrity": "sha512-/WUkirizeNAqwVj0zkcrqdQ9pUm1HY5kU+qy7xTR0OebkuJauglkmSTMD+56L1JPunWqHhlwCMVRaz5eaJdSEQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -984,9 +1017,9 @@
             }
         },
         "node_modules/@aws-sdk/util-middleware": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.329.0.tgz",
-            "integrity": "sha512-RhBOBaxzkTUghi4MSqr8S5qeeBCjgJ0XPJ6jIYkVkj1saCmqkuZCgl3zFaYdyhdxxPV6nflkFer+1HUoqT+Fqw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+            "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -995,11 +1028,11 @@
             }
         },
         "node_modules/@aws-sdk/util-retry": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.329.0.tgz",
-            "integrity": "sha512-+3VQ9HZLinysnmryUs9Xjt1YVh4TYYHLt30ilu4iUnIHFQoamdzIbRCWseSVFPCxGroen9M9qmAleAsytHEKuA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+            "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
             "dependencies": {
-                "@aws-sdk/service-error-classification": "3.329.0",
+                "@aws-sdk/service-error-classification": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1018,22 +1051,22 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.329.0.tgz",
-            "integrity": "sha512-8hLSmMCl8aw2++0Zuba8ELq8FkK6/VNyx470St201IpMn2GMbQMDl/rLolRKiTgji6wc+T3pOTidkJkz8/cIXA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+            "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
             "dependencies": {
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/types": "3.347.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.329.0.tgz",
-            "integrity": "sha512-C50Zaeodc0+psEP+L4WpElrH8epuLWJPVN4hDOTORcM0cSoU2o025Ost9mbcU7UdoHNxF9vitLnzORGN9SHolg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
+            "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
             "dependencies": {
-                "@aws-sdk/node-config-provider": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1069,12 +1102,12 @@
             }
         },
         "node_modules/@aws-sdk/util-waiter": {
-            "version": "3.329.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.329.0.tgz",
-            "integrity": "sha512-MIGs7snNL0ZV55zo1BDVPlrmbinUGV3260hp6HrW4zUbpYVoeIOGeewtrwAsF6FJ+vpZCxljPBB0X2jYR7Q7ZQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.347.0.tgz",
+            "integrity": "sha512-3ze/0PkwkzUzLncukx93tZgGL0JX9NaP8DxTi6WzflnL/TEul5Z63PCruRNK0om17iZYAWKrf8q2mFoHYb4grA==",
             "dependencies": {
-                "@aws-sdk/abort-controller": "3.329.0",
-                "@aws-sdk/types": "3.329.0",
+                "@aws-sdk/abort-controller": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1129,18 +1162,18 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.40.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.40.0.tgz",
-            "integrity": "sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==",
+            "version": "8.42.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
+            "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.8",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-            "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+            "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
             "dev": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.1",
@@ -1215,9 +1248,9 @@
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.1.0.tgz",
-            "integrity": "sha512-w1qd368vtrwttm1PRJWPW1QHlbmHrVDGs1eBH/jZvRPUFS4MNXV9Q33EQdjOdeAxZ7O8+3wM7zxztm2nfUSyKw==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.2.0.tgz",
+            "integrity": "sha512-OPwQlEdg40HAj5KNF8WW6q2KG4Z+cBCZb3m4ninfTZKaBmbIJodviQsDBoYMPHkOyJJMHnOJo5j2+LKDOhOACg==",
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0"
@@ -1248,6 +1281,29 @@
             "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
             "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
             "dev": true
+        },
+        "node_modules/@smithy/protocol-http": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
+            "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+            "dependencies": {
+                "@smithy/types": "^1.0.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/types": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
+            "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/acorn": {
             "version": "8.8.2",
@@ -1702,16 +1758,16 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.40.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.40.0.tgz",
-            "integrity": "sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==",
+            "version": "8.42.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz",
+            "integrity": "sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.4.0",
                 "@eslint/eslintrc": "^2.0.3",
-                "@eslint/js": "8.40.0",
-                "@humanwhocodes/config-array": "^0.11.8",
+                "@eslint/js": "8.42.0",
+                "@humanwhocodes/config-array": "^0.11.10",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "ajv": "^6.10.0",
@@ -1730,13 +1786,12 @@
                 "find-up": "^5.0.0",
                 "glob-parent": "^6.0.2",
                 "globals": "^13.19.0",
-                "grapheme-splitter": "^1.0.4",
+                "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "is-path-inside": "^3.0.3",
-                "js-sdsl": "^4.1.4",
                 "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
@@ -1927,18 +1982,24 @@
             "dev": true
         },
         "node_modules/fast-xml-parser": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-            "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+            "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+            "funding": [
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
             "dependencies": {
                 "strnum": "^1.0.5"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
-            },
-            "funding": {
-                "type": "paypal",
-                "url": "https://paypal.me/naturalintelligence"
             }
         },
         "node_modules/fastq": {
@@ -2159,10 +2220,10 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/grapheme-splitter": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+        "node_modules/graphemer": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
         },
         "node_modules/has": {
@@ -2394,9 +2455,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-            "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+            "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
             "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
@@ -2617,16 +2678,6 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
-        },
-        "node_modules/js-sdsl": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
-            "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
-            "dev": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/js-sdsl"
-            }
         },
         "node_modules/js-yaml": {
             "version": "4.1.0",
@@ -3132,13 +3183,13 @@
             }
         },
         "node_modules/sinon": {
-            "version": "15.0.4",
-            "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.4.tgz",
-            "integrity": "sha512-uzmfN6zx3GQaria1kwgWGeKiXSSbShBbue6Dcj0SI8fiCNFbiUDqKl57WFlY5lyhxZVUKmXvzgG2pilRQCBwWg==",
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.1.0.tgz",
+            "integrity": "sha512-cS5FgpDdE9/zx7no8bxROHymSlPLZzq0ChbbLk1DrxBfc+eTeBK3y8nIL+nu/0QeYydhhbLIr7ecHJpywjQaoQ==",
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0",
-                "@sinonjs/fake-timers": "^10.0.2",
+                "@sinonjs/fake-timers": "^10.2.0",
                 "@sinonjs/samsam": "^8.0.0",
                 "diff": "^5.1.0",
                 "nise": "^5.1.4",
@@ -3333,9 +3384,9 @@
             "dev": true
         },
         "node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/ingest-image/package-lock.json
+++ b/ingest-image/package-lock.json
@@ -151,11 +151,11 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/abort-controller": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.342.0.tgz",
-            "integrity": "sha512-W1lAYldbzDjfn8vwnwNe+6qNWfSu1+JrdiVIRSwsiwKvF2ahjKuaLoc8rJM09C6ieNWRi5634urFgfwAJuv6vg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+            "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -171,42 +171,42 @@
             }
         },
         "node_modules/@aws-sdk/client-batch": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-batch/-/client-batch-3.345.0.tgz",
-            "integrity": "sha512-zWfj0Hr7ZA4/t8rnKAVs6fVBCq+WyBsN03b9zQym4T6+hN8DqBzUr0SiUzHT8pams1RXTI5rwxll5WrZ9j1YbA==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-batch/-/client-batch-3.348.0.tgz",
+            "integrity": "sha512-OYTEtqadDoyUekyYFjwoI29NHLh2vc2O//F+0CVzkEqPE0s2PU6YCogEvdJyEGxUigWBnENOXDxiX6h8ZtWb5g==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.345.0",
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/credential-provider-node": "3.345.0",
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/hash-node": "3.344.0",
-                "@aws-sdk/invalid-dependency": "3.342.0",
-                "@aws-sdk/middleware-content-length": "3.342.0",
-                "@aws-sdk/middleware-endpoint": "3.344.0",
-                "@aws-sdk/middleware-host-header": "3.342.0",
-                "@aws-sdk/middleware-logger": "3.342.0",
-                "@aws-sdk/middleware-recursion-detection": "3.342.0",
-                "@aws-sdk/middleware-retry": "3.342.0",
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/middleware-signing": "3.342.0",
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/middleware-user-agent": "3.345.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/smithy-client": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-                "@aws-sdk/util-defaults-mode-node": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
-                "@aws-sdk/util-user-agent-browser": "3.345.0",
-                "@aws-sdk/util-user-agent-node": "3.345.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
@@ -217,47 +217,47 @@
             }
         },
         "node_modules/@aws-sdk/client-lambda": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.345.0.tgz",
-            "integrity": "sha512-A6GmCUcVr+zCYiy2xnquAM2CpxaVmwUW//UQ70yXugbg5U+tiV7EuAqbLtIXtDoaqAWPz1itnhdtKcfEBg/FrQ==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.348.0.tgz",
+            "integrity": "sha512-P7PzlPU9cfynfC2O2pSls8lBtLO5cYoYEfhWgPZUZS/tewOrX78qqLcQKPBToHiZY5zWGFr2iC2fDDTCbYnhfw==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.345.0",
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/credential-provider-node": "3.345.0",
-                "@aws-sdk/eventstream-serde-browser": "3.342.0",
-                "@aws-sdk/eventstream-serde-config-resolver": "3.342.0",
-                "@aws-sdk/eventstream-serde-node": "3.342.0",
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/hash-node": "3.344.0",
-                "@aws-sdk/invalid-dependency": "3.342.0",
-                "@aws-sdk/middleware-content-length": "3.342.0",
-                "@aws-sdk/middleware-endpoint": "3.344.0",
-                "@aws-sdk/middleware-host-header": "3.342.0",
-                "@aws-sdk/middleware-logger": "3.342.0",
-                "@aws-sdk/middleware-recursion-detection": "3.342.0",
-                "@aws-sdk/middleware-retry": "3.342.0",
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/middleware-signing": "3.342.0",
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/middleware-user-agent": "3.345.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/smithy-client": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/eventstream-serde-browser": "3.347.0",
+                "@aws-sdk/eventstream-serde-config-resolver": "3.347.0",
+                "@aws-sdk/eventstream-serde-node": "3.347.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-                "@aws-sdk/util-defaults-mode-node": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
-                "@aws-sdk/util-user-agent-browser": "3.345.0",
-                "@aws-sdk/util-user-agent-node": "3.345.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
-                "@aws-sdk/util-waiter": "3.342.0",
+                "@aws-sdk/util-waiter": "3.347.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
                 "tslib": "^2.5.0"
@@ -267,64 +267,64 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.345.0.tgz",
-            "integrity": "sha512-Vj1QGTkFOaWMP9jTVXX9NcNxLw1XY8w4hCXtQAzuUTepfqvA8K/EjeVhpG3Tc0tONeuPe4ee+2T1Q0BCKnf25w==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.348.0.tgz",
+            "integrity": "sha512-19ShUJL/Kqol4pW2S6axD85oL2JIh91ctUgqPEuu5BzGyEgq5s+HP/DDNzcdsTKl7gfCfaIULf01yWU6RwY1EA==",
             "dependencies": {
                 "@aws-crypto/sha1-browser": "3.0.0",
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.345.0",
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/credential-provider-node": "3.345.0",
-                "@aws-sdk/eventstream-serde-browser": "3.342.0",
-                "@aws-sdk/eventstream-serde-config-resolver": "3.342.0",
-                "@aws-sdk/eventstream-serde-node": "3.342.0",
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/hash-blob-browser": "3.342.0",
-                "@aws-sdk/hash-node": "3.344.0",
-                "@aws-sdk/hash-stream-node": "3.342.0",
-                "@aws-sdk/invalid-dependency": "3.342.0",
-                "@aws-sdk/md5-js": "3.342.0",
-                "@aws-sdk/middleware-bucket-endpoint": "3.342.0",
-                "@aws-sdk/middleware-content-length": "3.342.0",
-                "@aws-sdk/middleware-endpoint": "3.344.0",
-                "@aws-sdk/middleware-expect-continue": "3.342.0",
-                "@aws-sdk/middleware-flexible-checksums": "3.342.0",
-                "@aws-sdk/middleware-host-header": "3.342.0",
-                "@aws-sdk/middleware-location-constraint": "3.342.0",
-                "@aws-sdk/middleware-logger": "3.342.0",
-                "@aws-sdk/middleware-recursion-detection": "3.342.0",
-                "@aws-sdk/middleware-retry": "3.342.0",
-                "@aws-sdk/middleware-sdk-s3": "3.342.0",
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/middleware-signing": "3.342.0",
-                "@aws-sdk/middleware-ssec": "3.342.0",
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/middleware-user-agent": "3.345.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/signature-v4-multi-region": "3.344.0",
-                "@aws-sdk/smithy-client": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/eventstream-serde-browser": "3.347.0",
+                "@aws-sdk/eventstream-serde-config-resolver": "3.347.0",
+                "@aws-sdk/eventstream-serde-node": "3.347.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-blob-browser": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/hash-stream-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/md5-js": "3.347.0",
+                "@aws-sdk/middleware-bucket-endpoint": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-expect-continue": "3.347.0",
+                "@aws-sdk/middleware-flexible-checksums": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-location-constraint": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-sdk-s3": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-ssec": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/signature-v4-multi-region": "3.347.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-                "@aws-sdk/util-defaults-mode-node": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
-                "@aws-sdk/util-stream-browser": "3.342.0",
-                "@aws-sdk/util-stream-node": "3.344.0",
-                "@aws-sdk/util-user-agent-browser": "3.345.0",
-                "@aws-sdk/util-user-agent-node": "3.345.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-stream-browser": "3.347.0",
+                "@aws-sdk/util-stream-node": "3.348.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
-                "@aws-sdk/util-waiter": "3.342.0",
+                "@aws-sdk/util-waiter": "3.347.0",
                 "@aws-sdk/xml-builder": "3.310.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
-                "fast-xml-parser": "4.1.2",
+                "fast-xml-parser": "4.2.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -332,44 +332,44 @@
             }
         },
         "node_modules/@aws-sdk/client-ssm": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.345.0.tgz",
-            "integrity": "sha512-4uvi93brq+8GmLYzHNgDag4AuqgxprtQUgVs8Qh4gwusp/kSlcW96MbJUnthvYFUzfnyvJd1JmgZs3M+ypYKmg==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.348.0.tgz",
+            "integrity": "sha512-zqT7quggsJjOlhxl5D7JDNA9ufi0L9YqyHk3WygMCTjcuaaKLJJP1mVAHm2Ia3LvW3Vj4AdoXt0Tm2LmV0+cSQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.345.0",
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/credential-provider-node": "3.345.0",
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/hash-node": "3.344.0",
-                "@aws-sdk/invalid-dependency": "3.342.0",
-                "@aws-sdk/middleware-content-length": "3.342.0",
-                "@aws-sdk/middleware-endpoint": "3.344.0",
-                "@aws-sdk/middleware-host-header": "3.342.0",
-                "@aws-sdk/middleware-logger": "3.342.0",
-                "@aws-sdk/middleware-recursion-detection": "3.342.0",
-                "@aws-sdk/middleware-retry": "3.342.0",
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/middleware-signing": "3.342.0",
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/middleware-user-agent": "3.345.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/smithy-client": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-                "@aws-sdk/util-defaults-mode-node": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
-                "@aws-sdk/util-user-agent-browser": "3.345.0",
-                "@aws-sdk/util-user-agent-node": "3.345.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
-                "@aws-sdk/util-waiter": "3.342.0",
+                "@aws-sdk/util-waiter": "3.347.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
                 "tslib": "^2.5.0",
@@ -388,39 +388,39 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.345.0.tgz",
-            "integrity": "sha512-HZNz2AVK+4o149HlIPnVc0CQ7MqsaPqrDiCUBCSHH/wKFVTFMas/cbxx9zLq+pfUD+8p4eSYpd9fv8eHgZOZsg==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.348.0.tgz",
+            "integrity": "sha512-5S23gVKBl0fhZ96RD8LdPhMKeh8E5fmebyZxMNZuWliSXz++Q9ZCrwPwQbkks3duPOTcKKobs3IoqP82HoXMvQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/hash-node": "3.344.0",
-                "@aws-sdk/invalid-dependency": "3.342.0",
-                "@aws-sdk/middleware-content-length": "3.342.0",
-                "@aws-sdk/middleware-endpoint": "3.344.0",
-                "@aws-sdk/middleware-host-header": "3.342.0",
-                "@aws-sdk/middleware-logger": "3.342.0",
-                "@aws-sdk/middleware-recursion-detection": "3.342.0",
-                "@aws-sdk/middleware-retry": "3.342.0",
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/middleware-user-agent": "3.345.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/smithy-client": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-                "@aws-sdk/util-defaults-mode-node": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
-                "@aws-sdk/util-user-agent-browser": "3.345.0",
-                "@aws-sdk/util-user-agent-node": "3.345.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
@@ -431,39 +431,39 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.345.0.tgz",
-            "integrity": "sha512-vKF1Gl/04smhloujzPu+cud63jxgU3lsV+lt9J4HHOmsvTpfuTR/jSG88hfBM6Esmnzpz56u9qi7AZ5nlmSsgQ==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.348.0.tgz",
+            "integrity": "sha512-tvHpcycx4EALvk38I9rAOdPeHvBDezqIB4lrE7AvnOJljlvCcdQ2gXa9GDrwrM7zuYBIZMBRE/njTMrCwoOdAA==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/hash-node": "3.344.0",
-                "@aws-sdk/invalid-dependency": "3.342.0",
-                "@aws-sdk/middleware-content-length": "3.342.0",
-                "@aws-sdk/middleware-endpoint": "3.344.0",
-                "@aws-sdk/middleware-host-header": "3.342.0",
-                "@aws-sdk/middleware-logger": "3.342.0",
-                "@aws-sdk/middleware-recursion-detection": "3.342.0",
-                "@aws-sdk/middleware-retry": "3.342.0",
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/middleware-user-agent": "3.345.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/smithy-client": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-                "@aws-sdk/util-defaults-mode-node": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
-                "@aws-sdk/util-user-agent-browser": "3.345.0",
-                "@aws-sdk/util-user-agent-node": "3.345.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
@@ -474,46 +474,46 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.345.0.tgz",
-            "integrity": "sha512-OCnwqTegZr+HHkiVUlOEiKBDE03DDVOXGKM/GTRA9mOic5bukh4z1TwSZOgoqxhpix4fX8xE4sdp9408mcfWEQ==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.348.0.tgz",
+            "integrity": "sha512-4iaQlWAOHMEF4xjR/FB/ws3aUjXjJHwbsIcqbdYAxsKijDYYTZYCPc/gM0NE1yi28qlNYNhMzHipe5xTYbU2Eg==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/credential-provider-node": "3.345.0",
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/hash-node": "3.344.0",
-                "@aws-sdk/invalid-dependency": "3.342.0",
-                "@aws-sdk/middleware-content-length": "3.342.0",
-                "@aws-sdk/middleware-endpoint": "3.344.0",
-                "@aws-sdk/middleware-host-header": "3.342.0",
-                "@aws-sdk/middleware-logger": "3.342.0",
-                "@aws-sdk/middleware-recursion-detection": "3.342.0",
-                "@aws-sdk/middleware-retry": "3.342.0",
-                "@aws-sdk/middleware-sdk-sts": "3.342.0",
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/middleware-signing": "3.342.0",
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/middleware-user-agent": "3.345.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/smithy-client": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-sdk-sts": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-                "@aws-sdk/util-defaults-mode-node": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
-                "@aws-sdk/util-user-agent-browser": "3.345.0",
-                "@aws-sdk/util-user-agent-node": "3.345.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
-                "fast-xml-parser": "4.1.2",
+                "fast-xml-parser": "4.2.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -521,13 +521,13 @@
             }
         },
         "node_modules/@aws-sdk/config-resolver": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.342.0.tgz",
-            "integrity": "sha512-jUg6DTTrCvG8AOPv5NRJ6PSQSC5fEI2gVv4luzvrGkRJULYbIqpdfUYdW7jB3rWAWC79pQQr5lSqC5DWH91stw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
+            "integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-config-provider": "3.310.0",
-                "@aws-sdk/util-middleware": "3.342.0",
+                "@aws-sdk/util-middleware": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -535,12 +535,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.342.0.tgz",
-            "integrity": "sha512-mufOcoqdXZXkvA7u6hUcJz6wKpVaho8SRWCvJrGO4YkyudUAoI9KSP5R4U+gtneDJ2Y/IEKPuw8ugNfANa1J+A==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
+            "integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -548,14 +548,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-imds": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.342.0.tgz",
-            "integrity": "sha512-ReaHwFLfcsEYjDFvi95OFd+IU8frPwuAygwL56aiMT7Voc0oy3EqB3MFs3gzFxdLsJ0vw9TZMRbaouepAEVCkA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
+            "integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
             "dependencies": {
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -563,18 +563,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.345.0.tgz",
-            "integrity": "sha512-3uT4JXNaFjOIZSMOxOGzhoO6fINyoIxcLK7F1wtEesmD2Ddp8y7DANbBR8alkfirSbTanZK0CuK5PXDn+4GGYQ==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.348.0.tgz",
+            "integrity": "sha512-0IEH5mH/cz2iLyr/+pSa3sCsQcGADiLSEn6yivsXdfz1zDqBiv+ffDoL0+Pvnp+TKf8sA6OlX8PgoMoEBvBdKw==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.342.0",
-                "@aws-sdk/credential-provider-imds": "3.342.0",
-                "@aws-sdk/credential-provider-process": "3.342.0",
-                "@aws-sdk/credential-provider-sso": "3.345.0",
-                "@aws-sdk/credential-provider-web-identity": "3.342.0",
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/shared-ini-file-loader": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/credential-provider-env": "3.347.0",
+                "@aws-sdk/credential-provider-imds": "3.347.0",
+                "@aws-sdk/credential-provider-process": "3.347.0",
+                "@aws-sdk/credential-provider-sso": "3.348.0",
+                "@aws-sdk/credential-provider-web-identity": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -582,19 +582,19 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.345.0.tgz",
-            "integrity": "sha512-aNuEH3qFFGIrtRkmH2Py65xIQBFkqxZjjY+/XlQcAxmKTDjqb6CB6jvdA7K53GC7z8KGjOuK5d7TZCGW8ufxpg==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.348.0.tgz",
+            "integrity": "sha512-ngRWphm9e36i58KqVi7Z8WOub+k0cSl+JZaAmgfFm0+dsfBG5uheo598OeiwWV0DqlilvaQZFaMVQgG2SX/tHg==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.342.0",
-                "@aws-sdk/credential-provider-imds": "3.342.0",
-                "@aws-sdk/credential-provider-ini": "3.345.0",
-                "@aws-sdk/credential-provider-process": "3.342.0",
-                "@aws-sdk/credential-provider-sso": "3.345.0",
-                "@aws-sdk/credential-provider-web-identity": "3.342.0",
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/shared-ini-file-loader": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/credential-provider-env": "3.347.0",
+                "@aws-sdk/credential-provider-imds": "3.347.0",
+                "@aws-sdk/credential-provider-ini": "3.348.0",
+                "@aws-sdk/credential-provider-process": "3.347.0",
+                "@aws-sdk/credential-provider-sso": "3.348.0",
+                "@aws-sdk/credential-provider-web-identity": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -602,13 +602,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.342.0.tgz",
-            "integrity": "sha512-q03yJQPa4jnZtwKFW3yEYNMcpYH7wQzbEOEXjnXG4v8935oOttZjXBvRK7ax+f0D1ZHZFeFSashjw0A/bi1efQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
+            "integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/shared-ini-file-loader": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -616,15 +616,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.345.0.tgz",
-            "integrity": "sha512-SOcLWdLG/jv9L/X1Kx7G7Ma1Tojk3+vJ6oSKTjrRk5Y+7uErW5qfcOZ4vSjY8by3OCywJcg6jXHK4jDjJwfw1A==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.348.0.tgz",
+            "integrity": "sha512-5cQao705376KgGkLv9xgkQ3T5H7KdNddWuyoH2wDcrHd1BA2Lnrell3Yyh7R6jQeV7uCQE/z0ugUOKhDqNKIqQ==",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.345.0",
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/shared-ini-file-loader": "3.342.0",
-                "@aws-sdk/token-providers": "3.345.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/client-sso": "3.348.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/token-providers": "3.348.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -632,12 +632,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.342.0.tgz",
-            "integrity": "sha512-+an5oGnzoXMmGJql0Qs9MtyQTmz5GFqrWleQ0k9UVhN3uIfCS9AITS7vb+q1+G7A7YXy9+KshgBhcHco0G/JWQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
+            "integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -645,23 +645,23 @@
             }
         },
         "node_modules/@aws-sdk/eventstream-codec": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.342.0.tgz",
-            "integrity": "sha512-IwtvSuplioMyiu/pQgpazKkGWDM5M5BOx85zmsB0uNxt6rmje8+WqPmGmuPdmJv4bLC5dJPLovcCp/fuH8XWhA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+            "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
             "dependencies": {
                 "@aws-crypto/crc32": "3.0.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-hex-encoding": "3.310.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/eventstream-serde-browser": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.342.0.tgz",
-            "integrity": "sha512-IP+bbq6NRENuWong/PZdLcJo6Pv3tElrQOxD+XEQw4IIdFsSmHAoGGrQtMsGlPHAnEAM0KOTZDOeP/SdB+tKUw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.347.0.tgz",
+            "integrity": "sha512-9BLVTHWgpiTo/hl+k7qt7E9iYu43zVwJN+4TEwA9ZZB3p12068t1Hay6HgCcgJC3+LWMtw/OhvypV6vQAG4UBg==",
             "dependencies": {
-                "@aws-sdk/eventstream-serde-universal": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/eventstream-serde-universal": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -669,11 +669,11 @@
             }
         },
         "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.342.0.tgz",
-            "integrity": "sha512-sV4aqEk6JTm9LzTWH6oNlLzQM+560903VFFL05xTq0LHB5946T4rqCz+2Hg56wQJ5oII6EgzWuY8mieW/hUhew==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.347.0.tgz",
+            "integrity": "sha512-RcXQbNVq0PFmDqfn6+MnjCUWbbobcYVxpimaF6pMDav04o6Mcle+G2Hrefp5NlFr/lZbHW2eUKYsp1sXPaxVlQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -681,12 +681,12 @@
             }
         },
         "node_modules/@aws-sdk/eventstream-serde-node": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.342.0.tgz",
-            "integrity": "sha512-96KPMIJNZRHuMtaSH9wXuqakkWjT+z4KSnrycnnb4TgBqhenSU2qPEjVcseoCeJxls5mgYQOCQx65KV/ia46wA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.347.0.tgz",
+            "integrity": "sha512-pgQCWH0PkHjcHs04JE7FoGAD3Ww45ffV8Op0MSLUhg9OpGa6EDoO3EOpWi9l/TALtH4f0KRV35PVyUyHJ/wEkA==",
             "dependencies": {
-                "@aws-sdk/eventstream-serde-universal": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/eventstream-serde-universal": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -694,12 +694,12 @@
             }
         },
         "node_modules/@aws-sdk/eventstream-serde-universal": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.342.0.tgz",
-            "integrity": "sha512-B7sJu/GIEt1Bkvwt1I1oimYxM4CSA9DBA6PnNSbqD8BaCd+w8Rxcb35n6IohmfzLSbZxeI81p9XVD2q7BIY0Wg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.347.0.tgz",
+            "integrity": "sha512-4wWj6bz6lOyDIO/dCCjwaLwRz648xzQQnf89R29sLoEqvAPP5XOB7HL+uFaQ/f5tPNh49gL6huNFSVwDm62n4Q==",
             "dependencies": {
-                "@aws-sdk/eventstream-codec": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/eventstream-codec": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -707,33 +707,33 @@
             }
         },
         "node_modules/@aws-sdk/fetch-http-handler": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.342.0.tgz",
-            "integrity": "sha512-zsC23VUQMHEu4OKloLCVyWLG0ns6n+HKZ9euGLnNO3l0VSRne9qj/94yR+4jr/h04M7MhGf9mlczGfnZUFxs5w==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
+            "integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/querystring-builder": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/querystring-builder": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/hash-blob-browser": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.342.0.tgz",
-            "integrity": "sha512-fdCmHcFltKvp5TkYB4Qv9E1N98pc/mmWsFld7sQUomlr44Sdokf04QleYLjAPo9knX0P0moKuYlDHBuECaRNbw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.347.0.tgz",
+            "integrity": "sha512-RxgstIldLsdJKN5UHUwSI9PMiatr0xKmKxS4+tnWZ1/OOg6wuWqqpDpWdNOVSJSpxpUaP6kRrvG5Yo5ZevoTXw==",
             "dependencies": {
                 "@aws-sdk/chunked-blob-reader": "3.310.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/hash-node": {
-            "version": "3.344.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.344.0.tgz",
-            "integrity": "sha512-K0/mSvYR4hEfTRnnyoTj8ccqbXe2PpwvP4u8GXwk3Nr7s8qhDPYe8tFMv+6hoDJ50WJHrMTYGZ1HDAmjvP9uhA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+            "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-buffer-from": "3.310.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
@@ -743,11 +743,11 @@
             }
         },
         "node_modules/@aws-sdk/hash-stream-node": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.342.0.tgz",
-            "integrity": "sha512-8Ih3499SinJnuPAu1M7SBP5kF9zR8OsqD02VW8bO9jBpu1AYzs5k2OxTb86R+OWS6H+PJP6v1eTxNc9ZKUOhjg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.347.0.tgz",
+            "integrity": "sha512-tOBfcvELyt1GVuAlQ4d0mvm3QxoSSmvhH15SWIubM9RP4JWytBVzaFAn/aC02DBAWyvp0acMZ5J+47mxrWJElg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
             },
@@ -756,11 +756,11 @@
             }
         },
         "node_modules/@aws-sdk/invalid-dependency": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.342.0.tgz",
-            "integrity": "sha512-3qza2Br1jGKJi8toPYG9u5aGJ3sbGmJLgKDvlga7q3F8JaeB92He6muRJ07eyDvxZ9jiKhLZ2mtYoVcEjI7Mgw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+            "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             }
         },
@@ -776,22 +776,22 @@
             }
         },
         "node_modules/@aws-sdk/md5-js": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.342.0.tgz",
-            "integrity": "sha512-wtuvAgxz0DWfbXZyqzdkEXGYY1esEbgmjMj8gAoqomvbmiThOEisxNvHcCUJwgqs6vlPNP5pGBtgoHGF5J7JWA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.347.0.tgz",
+            "integrity": "sha512-mChE+7DByTY9H4cQ6fnWp2x5jf8e6OZN+AdLp6WQ+W99z35zBeqBxVmgm8ziJwkMIrkSTv9j3Y7T9Ve3RIcSfg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.342.0.tgz",
-            "integrity": "sha512-o6DNAmAt1MtCeg/mekcpIw/3Bcr9PAJM0Ogv3GUar2J8ziUDtaRGO0zm0YrQjsZf7E5+JLWMFL+OAeYeVV6QwA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.347.0.tgz",
+            "integrity": "sha512-i9n4ylkGmGvizVcTfN4L+oN10OCL2DKvyMa4cCAVE1TJrsnaE0g7IOOyJGUS8p5KJYQrKVR7kcsa2L1S0VeEcA==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-arn-parser": "3.310.0",
                 "@aws-sdk/util-config-provider": "3.310.0",
                 "tslib": "^2.5.0"
@@ -801,12 +801,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-content-length": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.342.0.tgz",
-            "integrity": "sha512-7LUMZqhihSAptGRFFQvuwt9nCLNzNPkGd1oU1RpVXw6YPQfKP9Ec5tgg4oUlv1t58IYQvdVj5ITKp4X2aUJVPg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+            "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -814,14 +814,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-endpoint": {
-            "version": "3.344.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.344.0.tgz",
-            "integrity": "sha512-rg4ysfusGw5tm8XTqNpdWo0wP0K79hZs3z1xkkskeSsMrbYiDn78Bkkt4s3JELUJY64VanQktPaKo08dNFYNZw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+            "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
             "dependencies": {
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
-                "@aws-sdk/util-middleware": "3.342.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
+                "@aws-sdk/util-middleware": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -829,12 +829,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-expect-continue": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.342.0.tgz",
-            "integrity": "sha512-ohSZfseSJGECogtaXS/9VntGBALkJhfpsI7sK3cC20XcBlTI55rpy1AmD4vy0BEjEUQYBrkGuKKdmlT8DnjDRA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.347.0.tgz",
+            "integrity": "sha512-95M1unD1ENL0tx35dfyenSfx0QuXBSKtOi/qJja6LfX5771C5fm5ZTOrsrzPFJvRg/wj8pCOVWRZk+d5+jvfOQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -842,15 +842,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-flexible-checksums": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.342.0.tgz",
-            "integrity": "sha512-D68clBx5IHILCe4u8zxr0YRUHmQR6wf6pmLC9ddw7qWMgUU3Nr7AzzWebFO+VkoS5rX3KqQ0xCwzBUtYvixaNQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.347.0.tgz",
+            "integrity": "sha512-Pda7VMAIyeHw9nMp29rxdFft3EF4KP/tz/vLB6bqVoBNbLujo5rxn3SGOgStgIz7fuMLQQfoWIsmvxUm+Fp+Dw==",
             "dependencies": {
                 "@aws-crypto/crc32": "3.0.0",
                 "@aws-crypto/crc32c": "3.0.0",
                 "@aws-sdk/is-array-buffer": "3.310.0",
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
             },
@@ -859,12 +859,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.342.0.tgz",
-            "integrity": "sha512-EOoix2D2Mk3NQtv7UVhJttfttGYechQxKuGvCI8+8iEKxqlyXaKqAkLR07BQb6epMYeKP4z1PfJm203Sf0WPUQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+            "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -872,11 +872,11 @@
             }
         },
         "node_modules/@aws-sdk/middleware-location-constraint": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.342.0.tgz",
-            "integrity": "sha512-lakeKpMZreCc1nVTkVfkdl5SuojfKNL2oJvXVDDUFJ91sYx9FmhAT3++kWAun2SrU2S4TNXJ2SQL/8ON8TtSYQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.347.0.tgz",
+            "integrity": "sha512-x5fcEV7q8fQ0OmUO+cLhN5iPqGoLWtC3+aKHIfRRb2BpOO1khyc1FKzsIAdeQz2hfktq4j+WsrmcPvFKv51pSg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -884,11 +884,11 @@
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.342.0.tgz",
-            "integrity": "sha512-wbkp85T7p9sHLNPMY6HAXHvLOp+vOubFT/XLIGtgRhYu5aRJSlVo9qlwtdZjyhEgIRQ6H/QUnqAN7Zgk5bCLSw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+            "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -896,12 +896,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.342.0.tgz",
-            "integrity": "sha512-KUDseSAz95kXCqnXEQxNObpviZ6F7eJ5lEgpi+ZehlzGDk/GyOVgjVuAyI7nNxWI5v0ZJ5nIDy+BH273dWbnmQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+            "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -909,15 +909,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-retry": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.342.0.tgz",
-            "integrity": "sha512-Bfllrjqs0bXNG7A3ydLjTAE5zPEdigG+/lDuEsCfB35gywZnnxqi6BjTeQ9Ss6gbEWX+WyXP7/oVdNaUDQUr9Q==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
+            "integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/service-error-classification": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/util-middleware": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/service-error-classification": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-middleware": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
                 "tslib": "^2.5.0",
                 "uuid": "^8.3.2"
             },
@@ -934,12 +934,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.342.0.tgz",
-            "integrity": "sha512-fGZBmeSvOLKo4k/CSoa2v2TNdbw6eszGaFekOqHrIyfTW/a+VTcz+/MBLF9Cq1gayF1udjqjS+qbKB2ZiR31tA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.347.0.tgz",
+            "integrity": "sha512-TLr92+HMvamrhJJ0VDhA/PiUh4rTNQz38B9dB9ikohTaRgm+duP+mRiIv16tNPZPGl8v82Thn7Ogk2qPByNDtg==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-arn-parser": "3.310.0",
                 "tslib": "^2.5.0"
             },
@@ -948,12 +948,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-sts": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.342.0.tgz",
-            "integrity": "sha512-eGcGDC+6UWKC87mex3voBVRcZN3hzFN6GVzWkTS574hDqp/uJG3yPk3Dltw0qf8skikTGi3/ZE+yAxerq/f5rg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
+            "integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
             "dependencies": {
-                "@aws-sdk/middleware-signing": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -961,11 +961,11 @@
             }
         },
         "node_modules/@aws-sdk/middleware-serde": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.342.0.tgz",
-            "integrity": "sha512-WRD+Cyu6+h1ymfPnAw4fI2q3zXjihJ55HFe1uRF8VPN4uBbJNfN3IqL38y/SMEdZ0gH9zNlRNxZLhR0q6SNZEQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+            "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -973,15 +973,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.342.0.tgz",
-            "integrity": "sha512-CFRQyPv4OjRGmFoB3OfKcQ0aHgS9VWC0YwoHnSWIcLt3Xltorug/Amk0obr/MFoIrktdlVtmvLEJ4Z+8cdsz8g==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
+            "integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/signature-v4": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/util-middleware": "3.342.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/signature-v4": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-middleware": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -989,11 +989,11 @@
             }
         },
         "node_modules/@aws-sdk/middleware-ssec": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.342.0.tgz",
-            "integrity": "sha512-KLyxh082ITudpzlwtIEIq7VfBGpz/BdFafJOnO5h3TwJcIPsCml7XqLzbrjej8cPINRIqnXwMw8Pow/jC6drDg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.347.0.tgz",
+            "integrity": "sha512-467VEi2elPmUGcHAgTmzhguZ3lwTpwK+3s+pk312uZtVsS9rP1MAknYhpS3ZvssiqBUVPx8m29cLcC6Tx5nOJg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1001,9 +1001,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-stack": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.342.0.tgz",
-            "integrity": "sha512-nDYtLAv9IZq8YFxtbyAiK/U1mtvtJS0DG6HiIPT5jpHcRpuWRHQ170EAW51zYts+21Ffj1VA6ZPkbup83+T6/w==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+            "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1012,13 +1012,13 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.345.0.tgz",
-            "integrity": "sha512-e3auH6sqwyKCXCFNwRWYKkvWWxDHhyEnVWoYJEHqDwG6iWRwKqTBigIHao0sIrSEtZlewtE5pdeuTb0xoY19ZA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.347.0.tgz",
+            "integrity": "sha512-wJbGN3OE1/daVCrwk49whhIr9E0j1N4gWwN/wi4WuyYIA+5lMUfVp0aGIOvZR+878DxuFz2hQ4XcZVT4K2WvQw==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1026,13 +1026,13 @@
             }
         },
         "node_modules/@aws-sdk/node-config-provider": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.342.0.tgz",
-            "integrity": "sha512-Mwkj4+zt64w7a8QDrI9q4SrEt7XRO30Vk0a0xENqcOGrKIPfF5aeqlw85NYLoGys+KV1oatqQ+k0GzKx8qTIdQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
+            "integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/shared-ini-file-loader": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1040,14 +1040,14 @@
             }
         },
         "node_modules/@aws-sdk/node-http-handler": {
-            "version": "3.344.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.344.0.tgz",
-            "integrity": "sha512-04o5rrFBd8VzzN0Pcs7EEsyC6dz1maILbA6vdXrDvVLYqaO40Tpx2E/3KA/jZtOpHcGXxgDw2rv1kjJesoiEMw==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.348.0.tgz",
+            "integrity": "sha512-wxdgc4tO5F6lN4wHr0CZ4TyIjDW/ORp4SJZdWYNs2L5J7+/SwqgJY2lxRlGi0i7Md+apAdE3sT3ukVQ/9pVfPg==",
             "dependencies": {
-                "@aws-sdk/abort-controller": "3.342.0",
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/querystring-builder": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/abort-controller": "3.347.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/querystring-builder": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1055,11 +1055,11 @@
             }
         },
         "node_modules/@aws-sdk/property-provider": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.342.0.tgz",
-            "integrity": "sha512-p4TR9yRakIpwupEH3BUijWMYThGG0q43n1ICcsBOcvWZpE636lIUw6nzFlOuBUwqyPfUyLbXzchvosYxfCl0jw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
+            "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1067,11 +1067,11 @@
             }
         },
         "node_modules/@aws-sdk/protocol-http": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.342.0.tgz",
-            "integrity": "sha512-zuF2urcTJBZ1tltPdTBQzRasuGB7+4Yfs9i5l0F7lE0luK5Azy6G+2r3WWENUNxFTYuP94GrrqaOhVyj8XXLPQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1079,11 +1079,11 @@
             }
         },
         "node_modules/@aws-sdk/querystring-builder": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.342.0.tgz",
-            "integrity": "sha512-tb3FbtC36a7XBYeupdKm60LeM0etp73I6/7pDAkzAlw7zJdvY0aQIvj1c0U6nZlwZF8sSSxC7vlamR+wCspdMw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+            "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-uri-escape": "3.310.0",
                 "tslib": "^2.5.0"
             },
@@ -1092,11 +1092,11 @@
             }
         },
         "node_modules/@aws-sdk/querystring-parser": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.342.0.tgz",
-            "integrity": "sha512-6svvr/LZW1EPJaARnOpjf92FIiK25wuO7fRq05gLTcTRAfUMDvub+oDg3Ro9EjJERumrYQrYCem5Qi4X9w8K2g==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+            "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1104,19 +1104,19 @@
             }
         },
         "node_modules/@aws-sdk/service-error-classification": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.342.0.tgz",
-            "integrity": "sha512-MwHO5McbdAVKxfQj1yhleboAXqrzcGoi9ODS+bwCwRfe2lakGzBBhu8zaGDlKYOdv5rS+yAPP/5fZZUiuZY8Bw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+            "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/shared-ini-file-loader": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.342.0.tgz",
-            "integrity": "sha512-kQG7TMQMhNp5+Y8vhGuO/+wU3K/dTx0xC0AKoDFiBf6EpDRmDfr2pPRnfJ9GwgS9haHxJ/3Uwc03swHMlsj20A==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
+            "integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1124,15 +1124,15 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.342.0.tgz",
-            "integrity": "sha512-OWrGO2UOa1ENpy0kYd2shK4sklQygWUqvWLx9FotDbjIeUIEfAnqoPq/QqcXVrNyT/UvPi4iIrjHJEO8JCNRmA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
+            "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
             "dependencies": {
-                "@aws-sdk/eventstream-codec": "3.342.0",
+                "@aws-sdk/eventstream-codec": "3.347.0",
                 "@aws-sdk/is-array-buffer": "3.310.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-middleware": "3.342.0",
+                "@aws-sdk/util-middleware": "3.347.0",
                 "@aws-sdk/util-uri-escape": "3.310.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
@@ -1142,13 +1142,13 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.344.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.344.0.tgz",
-            "integrity": "sha512-B5hN9b0Qa3UvpzsLjGIeCZ9AXE1qpwSXNXEeGcAdUIyf6lG3l+JMREKr+ZVaqAwAcZCOWmUyuuHIhkiK5YzClg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.347.0.tgz",
+            "integrity": "sha512-838h7pbRCVYWlTl8W+r5+Z5ld7uoBObgAn7/RB1MQ4JjlkfLdN7emiITG6ueVL+7gWZNZc/4dXR/FJSzCgrkxQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/signature-v4": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/signature-v4": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1164,12 +1164,12 @@
             }
         },
         "node_modules/@aws-sdk/smithy-client": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.342.0.tgz",
-            "integrity": "sha512-HQ4JejjHU2X7OAZPwixFG+EyPSjmoZqll7EvWjPSKyclWrM320haWWz1trVzjG/AgPfeDLfRkH/JoMr13lECew==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+            "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
             "dependencies": {
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1177,14 +1177,14 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.345.0.tgz",
-            "integrity": "sha512-Yhmc8j96LwFU3Fo6H2GYDTALZMGuuOw6PmYhjXa5kzgb9K7hfwiSn8hVyYTVenqkbyUdOuMI6BgXoIgZcdjFmA==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.348.0.tgz",
+            "integrity": "sha512-nTjoJkUsJUrJTZuqaeMD9PW2//Rdg2HgfDjiyC4jmAXtayWYCi11mqauurMaUHJ3p5qJ8f5xzxm6vBTbrftPag==",
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.345.0",
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/shared-ini-file-loader": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/client-sso-oidc": "3.348.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1192,9 +1192,9 @@
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.342.0.tgz",
-            "integrity": "sha512-5uyXVda/AgUpdZNJ9JPHxwyxr08miPiZ/CKSMcRdQVjcNnrdzY9m/iM9LvnQT44sQO+IEEkF2IoZIWvZcq199A==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1203,12 +1203,12 @@
             }
         },
         "node_modules/@aws-sdk/url-parser": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.342.0.tgz",
-            "integrity": "sha512-r4s/FDK6iywl8l4TqEwIwtNvxWO0kZes03c/yCiRYqxlkjVmbXEOodn5IAAweAeS9yqC3sl/wKbsaoBiGFn45g==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+            "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
             "dependencies": {
-                "@aws-sdk/querystring-parser": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/querystring-parser": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             }
         },
@@ -1278,12 +1278,12 @@
             }
         },
         "node_modules/@aws-sdk/util-defaults-mode-browser": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.342.0.tgz",
-            "integrity": "sha512-N1ZRvCLbrt4Re9MKU3pLYR0iO+H7GU7RsXG4yAq6DtSWT9WCw6xhIUpeV2T5uxWKL92o3WHNiGjwcebq+N73Bg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
+            "integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             },
@@ -1292,15 +1292,15 @@
             }
         },
         "node_modules/@aws-sdk/util-defaults-mode-node": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.342.0.tgz",
-            "integrity": "sha512-yNa/eX8sELnwM5NONOFR/PCJMHTNrUVklSo/QHy57CT/L3KOqosRNAMnDVMzH1QolGaVN/8jgtDI2xVsvlP+AA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
+            "integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
             "dependencies": {
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/credential-provider-imds": "3.342.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-imds": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1308,11 +1308,11 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.342.0.tgz",
-            "integrity": "sha512-ZsYF413hkVwSOjvZG6U0SshRtzSg6MtwzO+j90AjpaqgoHAxE5LjO5eVYFfPXTC2U8NhU7xkzASY6++e5bRRnw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.347.0.tgz",
+            "integrity": "sha512-/WUkirizeNAqwVj0zkcrqdQ9pUm1HY5kU+qy7xTR0OebkuJauglkmSTMD+56L1JPunWqHhlwCMVRaz5eaJdSEQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1342,9 +1342,9 @@
             }
         },
         "node_modules/@aws-sdk/util-middleware": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.342.0.tgz",
-            "integrity": "sha512-P2LYyMP4JUFZBy9DcMvCDxWU34mlShCyrqBZ1ouuGW7UMgRb1PTEvpLAVndIWn9H+1KGDFjMqOWp1FZHr4YZOA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+            "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1353,11 +1353,11 @@
             }
         },
         "node_modules/@aws-sdk/util-retry": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.342.0.tgz",
-            "integrity": "sha512-U1LXXtOMAQjU4H9gjYZng8auRponAH0t3vShHMKT8UQggT6Hwz1obdXUZgcLCtcjp/1aEK4MkDwk2JSjuUTaZw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+            "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
             "dependencies": {
-                "@aws-sdk/service-error-classification": "3.342.0",
+                "@aws-sdk/service-error-classification": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1365,12 +1365,12 @@
             }
         },
         "node_modules/@aws-sdk/util-stream-browser": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.342.0.tgz",
-            "integrity": "sha512-9mPBlD2cfZmJiZoBmDxJ/FxXsMVoxB74v4aa83Nrk4RUlGGXj4GYcuwP6R0+F0d+1jfKARAwlBozL6I+/ICmoQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.347.0.tgz",
+            "integrity": "sha512-pIbmzIJfyX26qG622uIESOmJSMGuBkhmNU7I98bzhYCet5ctC0ow9L5FZw9ljOE46P/HkEcsOhh+qTHyCXlCEQ==",
             "dependencies": {
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-hex-encoding": "3.310.0",
                 "@aws-sdk/util-utf8": "3.310.0",
@@ -1378,12 +1378,12 @@
             }
         },
         "node_modules/@aws-sdk/util-stream-node": {
-            "version": "3.344.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.344.0.tgz",
-            "integrity": "sha512-Qn2CdmJyt6I+ofokNl5sa8GfKbuKTne5lw6DOhtGVUbqegyRmCx04Qkxy1fe++jdvf7zqb8V8I95lmlvnGYX1Q==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.348.0.tgz",
+            "integrity": "sha512-MFXyMUWA2oD0smBZf+sdnuyxLw8nCqyMEgYbos+6grvF1Szxn5+zbYTZrEBYiICqD1xJRLbWTzFLJU7oYm6pUg==",
             "dependencies": {
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-buffer-from": "3.310.0",
                 "tslib": "^2.5.0"
             },
@@ -1403,22 +1403,22 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.345.0.tgz",
-            "integrity": "sha512-q0mUueczB8yQlbGje/1am/seDYvbrMdLXzOfZkSWcY7f0kLWqsdOVb/PvfFnlr9VZYy9EwVfqIXMfchHPxSD5Q==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+            "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.345.0.tgz",
-            "integrity": "sha512-82N+/Td+QtEoM1j5tepsaIy64nMzgw1/qedE3pyLTFGfuQN7iVVppgS6lSvotX0kzWCgTCYyf9gTOMBOvEaVfg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
+            "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
             "dependencies": {
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1454,12 +1454,12 @@
             }
         },
         "node_modules/@aws-sdk/util-waiter": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.342.0.tgz",
-            "integrity": "sha512-OkOdrvNW4fBPgYw022MLl2CfmnksSIOIoVvBjL042ksimwoc/pX8qofi4ZqnGrN+d0XifevL/+PMdIhJz4U+Sw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.347.0.tgz",
+            "integrity": "sha512-3ze/0PkwkzUzLncukx93tZgGL0JX9NaP8DxTi6WzflnL/TEul5Z63PCruRNK0om17iZYAWKrf8q2mFoHYb4grA==",
             "dependencies": {
-                "@aws-sdk/abort-controller": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/abort-controller": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -2233,18 +2233,24 @@
             "dev": true
         },
         "node_modules/fast-xml-parser": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-            "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+            "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+            "funding": [
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
             "dependencies": {
                 "strnum": "^1.0.5"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
-            },
-            "funding": {
-                "type": "paypal",
-                "url": "https://paypal.me/naturalintelligence"
             }
         },
         "node_modules/fastq": {
@@ -2376,9 +2382,9 @@
             "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
         },
         "node_modules/glob": {
-            "version": "10.2.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.6.tgz",
-            "integrity": "sha512-U/rnDpXJGF414QQQZv5uVsabTVxMSwzS5CH0p3DRCIV6ownl4f7PzGnkGmvlum2wB+9RlJWJZ6ACU1INnBqiPA==",
+            "version": "10.2.7",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.7.tgz",
+            "integrity": "sha512-jTKehsravOJo8IJxUGfZILnkvVJM/MOfHRs8QcXolVef2zNI9Tqyy5+SeuOAZd3upViEZQLyFpQhYiHLrMUNmA==",
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^2.0.3",
@@ -2769,9 +2775,9 @@
             "dev": true
         },
         "node_modules/node-abi": {
-            "version": "3.43.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.43.0.tgz",
-            "integrity": "sha512-QB0MMv+tn9Ur2DtJrc8y09n0n6sw88CyDniWSX2cHW10goQXYPK9ZpFJOktDS4ron501edPX6h9i7Pg+RnH5nQ==",
+            "version": "3.44.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.44.0.tgz",
+            "integrity": "sha512-MYjZTiAETGG28/7fBH1RjuY7vzDwYC5q5U4whCgM4jNEQcC0gAvN339LxXukmL2T2tGpzYTfp+LZ5RN7E5DwEg==",
             "dependencies": {
                 "semver": "^7.3.5"
             },

--- a/ingest-image/package-lock.json
+++ b/ingest-image/package-lock.json
@@ -171,15 +171,15 @@
             }
         },
         "node_modules/@aws-sdk/client-batch": {
-            "version": "3.348.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-batch/-/client-batch-3.348.0.tgz",
-            "integrity": "sha512-OYTEtqadDoyUekyYFjwoI29NHLh2vc2O//F+0CVzkEqPE0s2PU6YCogEvdJyEGxUigWBnENOXDxiX6h8ZtWb5g==",
+            "version": "3.350.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-batch/-/client-batch-3.350.0.tgz",
+            "integrity": "sha512-GzfMQoexsxZEoFcub/ro+wbRprDcrbRmxfLBq4EUPGR6GWLGN8apK6RTk5JbG6LP1KdQGjbkybUtmMb7JTnpXw==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/client-sts": "3.350.0",
                 "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/credential-provider-node": "3.350.0",
                 "@aws-sdk/fetch-http-handler": "3.347.0",
                 "@aws-sdk/hash-node": "3.347.0",
                 "@aws-sdk/invalid-dependency": "3.347.0",
@@ -194,7 +194,7 @@
                 "@aws-sdk/middleware-stack": "3.347.0",
                 "@aws-sdk/middleware-user-agent": "3.347.0",
                 "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/node-http-handler": "3.350.0",
                 "@aws-sdk/smithy-client": "3.347.0",
                 "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/url-parser": "3.347.0",
@@ -217,15 +217,15 @@
             }
         },
         "node_modules/@aws-sdk/client-lambda": {
-            "version": "3.348.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.348.0.tgz",
-            "integrity": "sha512-P7PzlPU9cfynfC2O2pSls8lBtLO5cYoYEfhWgPZUZS/tewOrX78qqLcQKPBToHiZY5zWGFr2iC2fDDTCbYnhfw==",
+            "version": "3.350.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.350.0.tgz",
+            "integrity": "sha512-/3RNUHwsOacmzM/ZHxzKsA9QmYOAWmbA/IYkZ/qMN7Xti6HQ8cIqVnfBIKcKJsC4BUAz31szCf5ULf/mgjPhQw==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/client-sts": "3.350.0",
                 "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/credential-provider-node": "3.350.0",
                 "@aws-sdk/eventstream-serde-browser": "3.347.0",
                 "@aws-sdk/eventstream-serde-config-resolver": "3.347.0",
                 "@aws-sdk/eventstream-serde-node": "3.347.0",
@@ -243,7 +243,7 @@
                 "@aws-sdk/middleware-stack": "3.347.0",
                 "@aws-sdk/middleware-user-agent": "3.347.0",
                 "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/node-http-handler": "3.350.0",
                 "@aws-sdk/smithy-client": "3.347.0",
                 "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/url-parser": "3.347.0",
@@ -267,16 +267,16 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.348.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.348.0.tgz",
-            "integrity": "sha512-19ShUJL/Kqol4pW2S6axD85oL2JIh91ctUgqPEuu5BzGyEgq5s+HP/DDNzcdsTKl7gfCfaIULf01yWU6RwY1EA==",
+            "version": "3.350.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.350.0.tgz",
+            "integrity": "sha512-VNIX3V7ZAcXlzAp/PDLZYsBNWtXrtNulsCPuJe9gXY0+KCstjYT2mkXXb2+ipkthZi+YT14jhveNqTBRkJqGPg==",
             "dependencies": {
                 "@aws-crypto/sha1-browser": "3.0.0",
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/client-sts": "3.350.0",
                 "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/credential-provider-node": "3.350.0",
                 "@aws-sdk/eventstream-serde-browser": "3.347.0",
                 "@aws-sdk/eventstream-serde-config-resolver": "3.347.0",
                 "@aws-sdk/eventstream-serde-node": "3.347.0",
@@ -303,7 +303,7 @@
                 "@aws-sdk/middleware-stack": "3.347.0",
                 "@aws-sdk/middleware-user-agent": "3.347.0",
                 "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/node-http-handler": "3.350.0",
                 "@aws-sdk/signature-v4-multi-region": "3.347.0",
                 "@aws-sdk/smithy-client": "3.347.0",
                 "@aws-sdk/types": "3.347.0",
@@ -316,7 +316,7 @@
                 "@aws-sdk/util-endpoints": "3.347.0",
                 "@aws-sdk/util-retry": "3.347.0",
                 "@aws-sdk/util-stream-browser": "3.347.0",
-                "@aws-sdk/util-stream-node": "3.348.0",
+                "@aws-sdk/util-stream-node": "3.350.0",
                 "@aws-sdk/util-user-agent-browser": "3.347.0",
                 "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
@@ -332,15 +332,15 @@
             }
         },
         "node_modules/@aws-sdk/client-ssm": {
-            "version": "3.348.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.348.0.tgz",
-            "integrity": "sha512-zqT7quggsJjOlhxl5D7JDNA9ufi0L9YqyHk3WygMCTjcuaaKLJJP1mVAHm2Ia3LvW3Vj4AdoXt0Tm2LmV0+cSQ==",
+            "version": "3.350.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.350.0.tgz",
+            "integrity": "sha512-Gs0fweUE+LYUy2/1kqsTwsyEswuyNDCq/eU4iRoU1WkOvNIGtqjTV8Rbh/0Og1CwlxUPPjaeQiQWpiofGvmbQQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/client-sts": "3.350.0",
                 "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/credential-provider-node": "3.350.0",
                 "@aws-sdk/fetch-http-handler": "3.347.0",
                 "@aws-sdk/hash-node": "3.347.0",
                 "@aws-sdk/invalid-dependency": "3.347.0",
@@ -355,7 +355,7 @@
                 "@aws-sdk/middleware-stack": "3.347.0",
                 "@aws-sdk/middleware-user-agent": "3.347.0",
                 "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/node-http-handler": "3.350.0",
                 "@aws-sdk/smithy-client": "3.347.0",
                 "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/url-parser": "3.347.0",
@@ -388,9 +388,9 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.348.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.348.0.tgz",
-            "integrity": "sha512-5S23gVKBl0fhZ96RD8LdPhMKeh8E5fmebyZxMNZuWliSXz++Q9ZCrwPwQbkks3duPOTcKKobs3IoqP82HoXMvQ==",
+            "version": "3.350.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.350.0.tgz",
+            "integrity": "sha512-2vpiv6SEjmQGK3ZueGzvTMG6NenjWp0CHjmda71d1Iqr+tZ2UlfC35+3ioU8JP+jiXLL+y9r+SCer3IC8N/i+Q==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
@@ -408,7 +408,7 @@
                 "@aws-sdk/middleware-stack": "3.347.0",
                 "@aws-sdk/middleware-user-agent": "3.347.0",
                 "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/node-http-handler": "3.350.0",
                 "@aws-sdk/smithy-client": "3.347.0",
                 "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/url-parser": "3.347.0",
@@ -431,9 +431,9 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.348.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.348.0.tgz",
-            "integrity": "sha512-tvHpcycx4EALvk38I9rAOdPeHvBDezqIB4lrE7AvnOJljlvCcdQ2gXa9GDrwrM7zuYBIZMBRE/njTMrCwoOdAA==",
+            "version": "3.350.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.350.0.tgz",
+            "integrity": "sha512-v3UrWIglg9PPzGXqhyGB/qPZ8ifiGM9r4LV8vve1TpiKsUdf1Khtx1eB8yqjNO0vIsYUF+j1C23QT1qAN2DcEA==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
@@ -451,7 +451,7 @@
                 "@aws-sdk/middleware-stack": "3.347.0",
                 "@aws-sdk/middleware-user-agent": "3.347.0",
                 "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/node-http-handler": "3.350.0",
                 "@aws-sdk/smithy-client": "3.347.0",
                 "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/url-parser": "3.347.0",
@@ -474,14 +474,14 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.348.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.348.0.tgz",
-            "integrity": "sha512-4iaQlWAOHMEF4xjR/FB/ws3aUjXjJHwbsIcqbdYAxsKijDYYTZYCPc/gM0NE1yi28qlNYNhMzHipe5xTYbU2Eg==",
+            "version": "3.350.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.350.0.tgz",
+            "integrity": "sha512-s8RsJ6upWQgeUt8GdV3j3ZeTS7BQXedk77RhZ7wzvVwAjO9wow4uS7Iyic4kS3Y/6d26s0MO2vP4bR6HW6U6ZQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
                 "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/credential-provider-node": "3.350.0",
                 "@aws-sdk/fetch-http-handler": "3.347.0",
                 "@aws-sdk/hash-node": "3.347.0",
                 "@aws-sdk/invalid-dependency": "3.347.0",
@@ -497,7 +497,7 @@
                 "@aws-sdk/middleware-stack": "3.347.0",
                 "@aws-sdk/middleware-user-agent": "3.347.0",
                 "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/node-http-handler": "3.350.0",
                 "@aws-sdk/smithy-client": "3.347.0",
                 "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/url-parser": "3.347.0",
@@ -563,14 +563,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.348.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.348.0.tgz",
-            "integrity": "sha512-0IEH5mH/cz2iLyr/+pSa3sCsQcGADiLSEn6yivsXdfz1zDqBiv+ffDoL0+Pvnp+TKf8sA6OlX8PgoMoEBvBdKw==",
+            "version": "3.350.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.350.0.tgz",
+            "integrity": "sha512-mGGU0PpnG0VDNKSuGi083U1egjprrU9/XoRtgf+iYvAKXRR/0XA4pGW5c7zpHY7m4iLhBuRj6N4oxQsH9cMtWg==",
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.347.0",
                 "@aws-sdk/credential-provider-imds": "3.347.0",
                 "@aws-sdk/credential-provider-process": "3.347.0",
-                "@aws-sdk/credential-provider-sso": "3.348.0",
+                "@aws-sdk/credential-provider-sso": "3.350.0",
                 "@aws-sdk/credential-provider-web-identity": "3.347.0",
                 "@aws-sdk/property-provider": "3.347.0",
                 "@aws-sdk/shared-ini-file-loader": "3.347.0",
@@ -582,15 +582,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.348.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.348.0.tgz",
-            "integrity": "sha512-ngRWphm9e36i58KqVi7Z8WOub+k0cSl+JZaAmgfFm0+dsfBG5uheo598OeiwWV0DqlilvaQZFaMVQgG2SX/tHg==",
+            "version": "3.350.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.350.0.tgz",
+            "integrity": "sha512-xmqwCFwj/CZPx6AKHNb24Kpr0eHW9VISt9r+SfgH8PaYg5cNyX1pKmMbQCket5ov+WvHEQtOK7aBafak7dhauA==",
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.347.0",
                 "@aws-sdk/credential-provider-imds": "3.347.0",
-                "@aws-sdk/credential-provider-ini": "3.348.0",
+                "@aws-sdk/credential-provider-ini": "3.350.0",
                 "@aws-sdk/credential-provider-process": "3.347.0",
-                "@aws-sdk/credential-provider-sso": "3.348.0",
+                "@aws-sdk/credential-provider-sso": "3.350.0",
                 "@aws-sdk/credential-provider-web-identity": "3.347.0",
                 "@aws-sdk/property-provider": "3.347.0",
                 "@aws-sdk/shared-ini-file-loader": "3.347.0",
@@ -616,14 +616,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.348.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.348.0.tgz",
-            "integrity": "sha512-5cQao705376KgGkLv9xgkQ3T5H7KdNddWuyoH2wDcrHd1BA2Lnrell3Yyh7R6jQeV7uCQE/z0ugUOKhDqNKIqQ==",
+            "version": "3.350.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.350.0.tgz",
+            "integrity": "sha512-u/3kv+PJeVawzBtWBei+IX1/z50mwhpPe3VrKSTns4CPUw8b5sqIYWkAaw5hxm0td69+xcL98RzIJsEpJc4QSQ==",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.348.0",
+                "@aws-sdk/client-sso": "3.350.0",
                 "@aws-sdk/property-provider": "3.347.0",
                 "@aws-sdk/shared-ini-file-loader": "3.347.0",
-                "@aws-sdk/token-providers": "3.348.0",
+                "@aws-sdk/token-providers": "3.350.0",
                 "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
@@ -1040,9 +1040,9 @@
             }
         },
         "node_modules/@aws-sdk/node-http-handler": {
-            "version": "3.348.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.348.0.tgz",
-            "integrity": "sha512-wxdgc4tO5F6lN4wHr0CZ4TyIjDW/ORp4SJZdWYNs2L5J7+/SwqgJY2lxRlGi0i7Md+apAdE3sT3ukVQ/9pVfPg==",
+            "version": "3.350.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+            "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
             "dependencies": {
                 "@aws-sdk/abort-controller": "3.347.0",
                 "@aws-sdk/protocol-http": "3.347.0",
@@ -1177,11 +1177,11 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.348.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.348.0.tgz",
-            "integrity": "sha512-nTjoJkUsJUrJTZuqaeMD9PW2//Rdg2HgfDjiyC4jmAXtayWYCi11mqauurMaUHJ3p5qJ8f5xzxm6vBTbrftPag==",
+            "version": "3.350.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.350.0.tgz",
+            "integrity": "sha512-VIfVMV5An1VQQ6bOKQTHPsRFHD3/YRGOPk9lDTVJGOK0G1DIFYd/10ZaLQ86rCWLck2lGhjxsOen2N2n6MtA0A==",
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.348.0",
+                "@aws-sdk/client-sso-oidc": "3.350.0",
                 "@aws-sdk/property-provider": "3.347.0",
                 "@aws-sdk/shared-ini-file-loader": "3.347.0",
                 "@aws-sdk/types": "3.347.0",
@@ -1378,11 +1378,11 @@
             }
         },
         "node_modules/@aws-sdk/util-stream-node": {
-            "version": "3.348.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.348.0.tgz",
-            "integrity": "sha512-MFXyMUWA2oD0smBZf+sdnuyxLw8nCqyMEgYbos+6grvF1Szxn5+zbYTZrEBYiICqD1xJRLbWTzFLJU7oYm6pUg==",
+            "version": "3.350.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.350.0.tgz",
+            "integrity": "sha512-qhcmYEAVMJPjCepog3WTFBaeP3XCkLBbUrM5/+LaB/FASKk+JeV8qBQyjYUd8EVb6Gsk7+y9SE3Tj+ChyHB4WA==",
             "dependencies": {
-                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/node-http-handler": "3.350.0",
                 "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-buffer-from": "3.310.0",
                 "tslib": "^2.5.0"
@@ -2775,9 +2775,9 @@
             "dev": true
         },
         "node_modules/node-abi": {
-            "version": "3.44.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.44.0.tgz",
-            "integrity": "sha512-MYjZTiAETGG28/7fBH1RjuY7vzDwYC5q5U4whCgM4jNEQcC0gAvN339LxXukmL2T2tGpzYTfp+LZ5RN7E5DwEg==",
+            "version": "3.45.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.45.0.tgz",
+            "integrity": "sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==",
             "dependencies": {
                 "semver": "^7.3.5"
             },

--- a/ingest-image/task.js
+++ b/ingest-image/task.js
@@ -143,6 +143,7 @@ export default class Task {
                 }
             })).data.createImage.image._id;
 
+            md._id = image_id;
             await this.copy_to_prod(md);
             await this.copy_to_archive(md);
         } catch (err) {
@@ -193,7 +194,7 @@ export default class Task {
     async copy_to_archive(md) {
         const Bucket = md['ArchiveBucket'];
         const parse = path.parse(md.FileName);
-        const archive_filename = parse.name + '_' + md['Hash'] + parse.ext;
+        const archive_filename = parse.name + '_' + md['_id'] + parse.ext;
         const Key = path.join(String(md['SerialNumber']), archive_filename);
 
         console.log(`Transferring s3://${Bucket}/${Key}`);
@@ -225,7 +226,7 @@ export default class Task {
 
         for (const size in this.IMG_SIZES) {
             // create filename and key
-            const filename = `${md.Hash}-${size}.${md.FileTypeExtension}`;
+            const filename = `${md._id}-${size}.${md.FileTypeExtension}`;
             const Key = path.join(size, filename);
             console.log(`Transferring ${Key} to ${Bucket}`);
 

--- a/ingest-image/task.js
+++ b/ingest-image/task.js
@@ -302,7 +302,7 @@ export default class Task {
     }
 
     validate(file_name) {
-        const ext = path.parse(file_name).ext;
+        const ext = path.parse(file_name).ext.toLowerCase();
 
         if (this.SUPPORTED_FILE_TYPES.includes(ext)) {
             return IngestType.IMAGE;

--- a/ingest-image/task.js
+++ b/ingest-image/task.js
@@ -164,7 +164,7 @@ export default class Task {
                     variables: {
                         input: {
                             error: err.message,
-                            image: md.Hash,
+                            image: image_id,
                             batch: md.batchId ? md.batchId : undefined
                         }
                     }

--- a/ingest-zip/index.js
+++ b/ingest-zip/index.js
@@ -64,7 +64,7 @@ export default async function handler() {
             const parsed = path.parse(entry.name);
             if (!parsed.ext) continue;
             if (parsed.base[0] === '.') continue;
-            if (!SUPPORTED_FILE_TYPES.includes(parsed.ext)) continue;
+            if (!SUPPORTED_FILE_TYPES.includes(parsed.ext.toLowerCase())) continue;
             total++;
         }
 
@@ -129,7 +129,7 @@ export default async function handler() {
             const parsed = path.parse(entry.name);
             if (!parsed.ext) return;
             if (parsed.base[0] === '.') return;
-            if (!SUPPORTED_FILE_TYPES.includes(parsed.ext)) return;
+            if (!SUPPORTED_FILE_TYPES.includes(parsed.ext.toLowerCase())) return;
 
             const data = await prezip.entryData(entry);
 

--- a/ingest-zip/package-lock.json
+++ b/ingest-zip/package-lock.json
@@ -150,11 +150,11 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/abort-controller": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.342.0.tgz",
-            "integrity": "sha512-W1lAYldbzDjfn8vwnwNe+6qNWfSu1+JrdiVIRSwsiwKvF2ahjKuaLoc8rJM09C6ieNWRi5634urFgfwAJuv6vg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+            "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -170,47 +170,47 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudformation": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.345.0.tgz",
-            "integrity": "sha512-fbTHEhc6ALzVwLBKw9qfLC9XP5szFcd2yxcBdyMypsTzjbOk2cOOEn9BfjRCzpkVNwO3UhSs/vcfiQFUnCWN5w==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.348.0.tgz",
+            "integrity": "sha512-F1WLJhJWMjzzmxuRfXMnPIT0UkOSGZSMBDkcIt3Jn275H8G1uY/sK/XFUDZEKSwiduo1dNhMhZDMURLOEr4N8g==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.345.0",
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/credential-provider-node": "3.345.0",
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/hash-node": "3.344.0",
-                "@aws-sdk/invalid-dependency": "3.342.0",
-                "@aws-sdk/middleware-content-length": "3.342.0",
-                "@aws-sdk/middleware-endpoint": "3.344.0",
-                "@aws-sdk/middleware-host-header": "3.342.0",
-                "@aws-sdk/middleware-logger": "3.342.0",
-                "@aws-sdk/middleware-recursion-detection": "3.342.0",
-                "@aws-sdk/middleware-retry": "3.342.0",
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/middleware-signing": "3.342.0",
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/middleware-user-agent": "3.345.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/smithy-client": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-                "@aws-sdk/util-defaults-mode-node": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
-                "@aws-sdk/util-user-agent-browser": "3.345.0",
-                "@aws-sdk/util-user-agent-node": "3.345.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
-                "@aws-sdk/util-waiter": "3.342.0",
+                "@aws-sdk/util-waiter": "3.347.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
-                "fast-xml-parser": "4.1.2",
+                "fast-xml-parser": "4.2.4",
                 "tslib": "^2.5.0",
                 "uuid": "^8.3.2"
             },
@@ -219,64 +219,64 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.345.0.tgz",
-            "integrity": "sha512-Vj1QGTkFOaWMP9jTVXX9NcNxLw1XY8w4hCXtQAzuUTepfqvA8K/EjeVhpG3Tc0tONeuPe4ee+2T1Q0BCKnf25w==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.348.0.tgz",
+            "integrity": "sha512-19ShUJL/Kqol4pW2S6axD85oL2JIh91ctUgqPEuu5BzGyEgq5s+HP/DDNzcdsTKl7gfCfaIULf01yWU6RwY1EA==",
             "dependencies": {
                 "@aws-crypto/sha1-browser": "3.0.0",
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.345.0",
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/credential-provider-node": "3.345.0",
-                "@aws-sdk/eventstream-serde-browser": "3.342.0",
-                "@aws-sdk/eventstream-serde-config-resolver": "3.342.0",
-                "@aws-sdk/eventstream-serde-node": "3.342.0",
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/hash-blob-browser": "3.342.0",
-                "@aws-sdk/hash-node": "3.344.0",
-                "@aws-sdk/hash-stream-node": "3.342.0",
-                "@aws-sdk/invalid-dependency": "3.342.0",
-                "@aws-sdk/md5-js": "3.342.0",
-                "@aws-sdk/middleware-bucket-endpoint": "3.342.0",
-                "@aws-sdk/middleware-content-length": "3.342.0",
-                "@aws-sdk/middleware-endpoint": "3.344.0",
-                "@aws-sdk/middleware-expect-continue": "3.342.0",
-                "@aws-sdk/middleware-flexible-checksums": "3.342.0",
-                "@aws-sdk/middleware-host-header": "3.342.0",
-                "@aws-sdk/middleware-location-constraint": "3.342.0",
-                "@aws-sdk/middleware-logger": "3.342.0",
-                "@aws-sdk/middleware-recursion-detection": "3.342.0",
-                "@aws-sdk/middleware-retry": "3.342.0",
-                "@aws-sdk/middleware-sdk-s3": "3.342.0",
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/middleware-signing": "3.342.0",
-                "@aws-sdk/middleware-ssec": "3.342.0",
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/middleware-user-agent": "3.345.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/signature-v4-multi-region": "3.344.0",
-                "@aws-sdk/smithy-client": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/eventstream-serde-browser": "3.347.0",
+                "@aws-sdk/eventstream-serde-config-resolver": "3.347.0",
+                "@aws-sdk/eventstream-serde-node": "3.347.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-blob-browser": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/hash-stream-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/md5-js": "3.347.0",
+                "@aws-sdk/middleware-bucket-endpoint": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-expect-continue": "3.347.0",
+                "@aws-sdk/middleware-flexible-checksums": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-location-constraint": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-sdk-s3": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-ssec": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/signature-v4-multi-region": "3.347.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-                "@aws-sdk/util-defaults-mode-node": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
-                "@aws-sdk/util-stream-browser": "3.342.0",
-                "@aws-sdk/util-stream-node": "3.344.0",
-                "@aws-sdk/util-user-agent-browser": "3.345.0",
-                "@aws-sdk/util-user-agent-node": "3.345.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-stream-browser": "3.347.0",
+                "@aws-sdk/util-stream-node": "3.348.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
-                "@aws-sdk/util-waiter": "3.342.0",
+                "@aws-sdk/util-waiter": "3.347.0",
                 "@aws-sdk/xml-builder": "3.310.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
-                "fast-xml-parser": "4.1.2",
+                "fast-xml-parser": "4.2.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -284,44 +284,44 @@
             }
         },
         "node_modules/@aws-sdk/client-ssm": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.345.0.tgz",
-            "integrity": "sha512-4uvi93brq+8GmLYzHNgDag4AuqgxprtQUgVs8Qh4gwusp/kSlcW96MbJUnthvYFUzfnyvJd1JmgZs3M+ypYKmg==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.348.0.tgz",
+            "integrity": "sha512-zqT7quggsJjOlhxl5D7JDNA9ufi0L9YqyHk3WygMCTjcuaaKLJJP1mVAHm2Ia3LvW3Vj4AdoXt0Tm2LmV0+cSQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.345.0",
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/credential-provider-node": "3.345.0",
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/hash-node": "3.344.0",
-                "@aws-sdk/invalid-dependency": "3.342.0",
-                "@aws-sdk/middleware-content-length": "3.342.0",
-                "@aws-sdk/middleware-endpoint": "3.344.0",
-                "@aws-sdk/middleware-host-header": "3.342.0",
-                "@aws-sdk/middleware-logger": "3.342.0",
-                "@aws-sdk/middleware-recursion-detection": "3.342.0",
-                "@aws-sdk/middleware-retry": "3.342.0",
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/middleware-signing": "3.342.0",
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/middleware-user-agent": "3.345.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/smithy-client": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-                "@aws-sdk/util-defaults-mode-node": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
-                "@aws-sdk/util-user-agent-browser": "3.345.0",
-                "@aws-sdk/util-user-agent-node": "3.345.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
-                "@aws-sdk/util-waiter": "3.342.0",
+                "@aws-sdk/util-waiter": "3.347.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
                 "tslib": "^2.5.0",
@@ -332,39 +332,39 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.345.0.tgz",
-            "integrity": "sha512-HZNz2AVK+4o149HlIPnVc0CQ7MqsaPqrDiCUBCSHH/wKFVTFMas/cbxx9zLq+pfUD+8p4eSYpd9fv8eHgZOZsg==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.348.0.tgz",
+            "integrity": "sha512-5S23gVKBl0fhZ96RD8LdPhMKeh8E5fmebyZxMNZuWliSXz++Q9ZCrwPwQbkks3duPOTcKKobs3IoqP82HoXMvQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/hash-node": "3.344.0",
-                "@aws-sdk/invalid-dependency": "3.342.0",
-                "@aws-sdk/middleware-content-length": "3.342.0",
-                "@aws-sdk/middleware-endpoint": "3.344.0",
-                "@aws-sdk/middleware-host-header": "3.342.0",
-                "@aws-sdk/middleware-logger": "3.342.0",
-                "@aws-sdk/middleware-recursion-detection": "3.342.0",
-                "@aws-sdk/middleware-retry": "3.342.0",
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/middleware-user-agent": "3.345.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/smithy-client": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-                "@aws-sdk/util-defaults-mode-node": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
-                "@aws-sdk/util-user-agent-browser": "3.345.0",
-                "@aws-sdk/util-user-agent-node": "3.345.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
@@ -375,39 +375,39 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.345.0.tgz",
-            "integrity": "sha512-vKF1Gl/04smhloujzPu+cud63jxgU3lsV+lt9J4HHOmsvTpfuTR/jSG88hfBM6Esmnzpz56u9qi7AZ5nlmSsgQ==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.348.0.tgz",
+            "integrity": "sha512-tvHpcycx4EALvk38I9rAOdPeHvBDezqIB4lrE7AvnOJljlvCcdQ2gXa9GDrwrM7zuYBIZMBRE/njTMrCwoOdAA==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/hash-node": "3.344.0",
-                "@aws-sdk/invalid-dependency": "3.342.0",
-                "@aws-sdk/middleware-content-length": "3.342.0",
-                "@aws-sdk/middleware-endpoint": "3.344.0",
-                "@aws-sdk/middleware-host-header": "3.342.0",
-                "@aws-sdk/middleware-logger": "3.342.0",
-                "@aws-sdk/middleware-recursion-detection": "3.342.0",
-                "@aws-sdk/middleware-retry": "3.342.0",
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/middleware-user-agent": "3.345.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/smithy-client": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-                "@aws-sdk/util-defaults-mode-node": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
-                "@aws-sdk/util-user-agent-browser": "3.345.0",
-                "@aws-sdk/util-user-agent-node": "3.345.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
@@ -418,46 +418,46 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.345.0.tgz",
-            "integrity": "sha512-OCnwqTegZr+HHkiVUlOEiKBDE03DDVOXGKM/GTRA9mOic5bukh4z1TwSZOgoqxhpix4fX8xE4sdp9408mcfWEQ==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.348.0.tgz",
+            "integrity": "sha512-4iaQlWAOHMEF4xjR/FB/ws3aUjXjJHwbsIcqbdYAxsKijDYYTZYCPc/gM0NE1yi28qlNYNhMzHipe5xTYbU2Eg==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/credential-provider-node": "3.345.0",
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/hash-node": "3.344.0",
-                "@aws-sdk/invalid-dependency": "3.342.0",
-                "@aws-sdk/middleware-content-length": "3.342.0",
-                "@aws-sdk/middleware-endpoint": "3.344.0",
-                "@aws-sdk/middleware-host-header": "3.342.0",
-                "@aws-sdk/middleware-logger": "3.342.0",
-                "@aws-sdk/middleware-recursion-detection": "3.342.0",
-                "@aws-sdk/middleware-retry": "3.342.0",
-                "@aws-sdk/middleware-sdk-sts": "3.342.0",
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/middleware-signing": "3.342.0",
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/middleware-user-agent": "3.345.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/smithy-client": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-sdk-sts": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-                "@aws-sdk/util-defaults-mode-node": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
-                "@aws-sdk/util-user-agent-browser": "3.345.0",
-                "@aws-sdk/util-user-agent-node": "3.345.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
-                "fast-xml-parser": "4.1.2",
+                "fast-xml-parser": "4.2.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -465,13 +465,13 @@
             }
         },
         "node_modules/@aws-sdk/config-resolver": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.342.0.tgz",
-            "integrity": "sha512-jUg6DTTrCvG8AOPv5NRJ6PSQSC5fEI2gVv4luzvrGkRJULYbIqpdfUYdW7jB3rWAWC79pQQr5lSqC5DWH91stw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
+            "integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-config-provider": "3.310.0",
-                "@aws-sdk/util-middleware": "3.342.0",
+                "@aws-sdk/util-middleware": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -479,12 +479,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.342.0.tgz",
-            "integrity": "sha512-mufOcoqdXZXkvA7u6hUcJz6wKpVaho8SRWCvJrGO4YkyudUAoI9KSP5R4U+gtneDJ2Y/IEKPuw8ugNfANa1J+A==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
+            "integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -492,14 +492,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-imds": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.342.0.tgz",
-            "integrity": "sha512-ReaHwFLfcsEYjDFvi95OFd+IU8frPwuAygwL56aiMT7Voc0oy3EqB3MFs3gzFxdLsJ0vw9TZMRbaouepAEVCkA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
+            "integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
             "dependencies": {
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -507,18 +507,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.345.0.tgz",
-            "integrity": "sha512-3uT4JXNaFjOIZSMOxOGzhoO6fINyoIxcLK7F1wtEesmD2Ddp8y7DANbBR8alkfirSbTanZK0CuK5PXDn+4GGYQ==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.348.0.tgz",
+            "integrity": "sha512-0IEH5mH/cz2iLyr/+pSa3sCsQcGADiLSEn6yivsXdfz1zDqBiv+ffDoL0+Pvnp+TKf8sA6OlX8PgoMoEBvBdKw==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.342.0",
-                "@aws-sdk/credential-provider-imds": "3.342.0",
-                "@aws-sdk/credential-provider-process": "3.342.0",
-                "@aws-sdk/credential-provider-sso": "3.345.0",
-                "@aws-sdk/credential-provider-web-identity": "3.342.0",
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/shared-ini-file-loader": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/credential-provider-env": "3.347.0",
+                "@aws-sdk/credential-provider-imds": "3.347.0",
+                "@aws-sdk/credential-provider-process": "3.347.0",
+                "@aws-sdk/credential-provider-sso": "3.348.0",
+                "@aws-sdk/credential-provider-web-identity": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -526,19 +526,19 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.345.0.tgz",
-            "integrity": "sha512-aNuEH3qFFGIrtRkmH2Py65xIQBFkqxZjjY+/XlQcAxmKTDjqb6CB6jvdA7K53GC7z8KGjOuK5d7TZCGW8ufxpg==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.348.0.tgz",
+            "integrity": "sha512-ngRWphm9e36i58KqVi7Z8WOub+k0cSl+JZaAmgfFm0+dsfBG5uheo598OeiwWV0DqlilvaQZFaMVQgG2SX/tHg==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.342.0",
-                "@aws-sdk/credential-provider-imds": "3.342.0",
-                "@aws-sdk/credential-provider-ini": "3.345.0",
-                "@aws-sdk/credential-provider-process": "3.342.0",
-                "@aws-sdk/credential-provider-sso": "3.345.0",
-                "@aws-sdk/credential-provider-web-identity": "3.342.0",
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/shared-ini-file-loader": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/credential-provider-env": "3.347.0",
+                "@aws-sdk/credential-provider-imds": "3.347.0",
+                "@aws-sdk/credential-provider-ini": "3.348.0",
+                "@aws-sdk/credential-provider-process": "3.347.0",
+                "@aws-sdk/credential-provider-sso": "3.348.0",
+                "@aws-sdk/credential-provider-web-identity": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -546,13 +546,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.342.0.tgz",
-            "integrity": "sha512-q03yJQPa4jnZtwKFW3yEYNMcpYH7wQzbEOEXjnXG4v8935oOttZjXBvRK7ax+f0D1ZHZFeFSashjw0A/bi1efQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
+            "integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/shared-ini-file-loader": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -560,15 +560,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.345.0.tgz",
-            "integrity": "sha512-SOcLWdLG/jv9L/X1Kx7G7Ma1Tojk3+vJ6oSKTjrRk5Y+7uErW5qfcOZ4vSjY8by3OCywJcg6jXHK4jDjJwfw1A==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.348.0.tgz",
+            "integrity": "sha512-5cQao705376KgGkLv9xgkQ3T5H7KdNddWuyoH2wDcrHd1BA2Lnrell3Yyh7R6jQeV7uCQE/z0ugUOKhDqNKIqQ==",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.345.0",
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/shared-ini-file-loader": "3.342.0",
-                "@aws-sdk/token-providers": "3.345.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/client-sso": "3.348.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/token-providers": "3.348.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -576,12 +576,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.342.0.tgz",
-            "integrity": "sha512-+an5oGnzoXMmGJql0Qs9MtyQTmz5GFqrWleQ0k9UVhN3uIfCS9AITS7vb+q1+G7A7YXy9+KshgBhcHco0G/JWQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
+            "integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -589,23 +589,23 @@
             }
         },
         "node_modules/@aws-sdk/eventstream-codec": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.342.0.tgz",
-            "integrity": "sha512-IwtvSuplioMyiu/pQgpazKkGWDM5M5BOx85zmsB0uNxt6rmje8+WqPmGmuPdmJv4bLC5dJPLovcCp/fuH8XWhA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+            "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
             "dependencies": {
                 "@aws-crypto/crc32": "3.0.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-hex-encoding": "3.310.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/eventstream-serde-browser": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.342.0.tgz",
-            "integrity": "sha512-IP+bbq6NRENuWong/PZdLcJo6Pv3tElrQOxD+XEQw4IIdFsSmHAoGGrQtMsGlPHAnEAM0KOTZDOeP/SdB+tKUw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.347.0.tgz",
+            "integrity": "sha512-9BLVTHWgpiTo/hl+k7qt7E9iYu43zVwJN+4TEwA9ZZB3p12068t1Hay6HgCcgJC3+LWMtw/OhvypV6vQAG4UBg==",
             "dependencies": {
-                "@aws-sdk/eventstream-serde-universal": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/eventstream-serde-universal": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -613,11 +613,11 @@
             }
         },
         "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.342.0.tgz",
-            "integrity": "sha512-sV4aqEk6JTm9LzTWH6oNlLzQM+560903VFFL05xTq0LHB5946T4rqCz+2Hg56wQJ5oII6EgzWuY8mieW/hUhew==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.347.0.tgz",
+            "integrity": "sha512-RcXQbNVq0PFmDqfn6+MnjCUWbbobcYVxpimaF6pMDav04o6Mcle+G2Hrefp5NlFr/lZbHW2eUKYsp1sXPaxVlQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -625,12 +625,12 @@
             }
         },
         "node_modules/@aws-sdk/eventstream-serde-node": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.342.0.tgz",
-            "integrity": "sha512-96KPMIJNZRHuMtaSH9wXuqakkWjT+z4KSnrycnnb4TgBqhenSU2qPEjVcseoCeJxls5mgYQOCQx65KV/ia46wA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.347.0.tgz",
+            "integrity": "sha512-pgQCWH0PkHjcHs04JE7FoGAD3Ww45ffV8Op0MSLUhg9OpGa6EDoO3EOpWi9l/TALtH4f0KRV35PVyUyHJ/wEkA==",
             "dependencies": {
-                "@aws-sdk/eventstream-serde-universal": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/eventstream-serde-universal": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -638,12 +638,12 @@
             }
         },
         "node_modules/@aws-sdk/eventstream-serde-universal": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.342.0.tgz",
-            "integrity": "sha512-B7sJu/GIEt1Bkvwt1I1oimYxM4CSA9DBA6PnNSbqD8BaCd+w8Rxcb35n6IohmfzLSbZxeI81p9XVD2q7BIY0Wg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.347.0.tgz",
+            "integrity": "sha512-4wWj6bz6lOyDIO/dCCjwaLwRz648xzQQnf89R29sLoEqvAPP5XOB7HL+uFaQ/f5tPNh49gL6huNFSVwDm62n4Q==",
             "dependencies": {
-                "@aws-sdk/eventstream-codec": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/eventstream-codec": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -651,33 +651,33 @@
             }
         },
         "node_modules/@aws-sdk/fetch-http-handler": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.342.0.tgz",
-            "integrity": "sha512-zsC23VUQMHEu4OKloLCVyWLG0ns6n+HKZ9euGLnNO3l0VSRne9qj/94yR+4jr/h04M7MhGf9mlczGfnZUFxs5w==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
+            "integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/querystring-builder": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/querystring-builder": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/hash-blob-browser": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.342.0.tgz",
-            "integrity": "sha512-fdCmHcFltKvp5TkYB4Qv9E1N98pc/mmWsFld7sQUomlr44Sdokf04QleYLjAPo9knX0P0moKuYlDHBuECaRNbw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.347.0.tgz",
+            "integrity": "sha512-RxgstIldLsdJKN5UHUwSI9PMiatr0xKmKxS4+tnWZ1/OOg6wuWqqpDpWdNOVSJSpxpUaP6kRrvG5Yo5ZevoTXw==",
             "dependencies": {
                 "@aws-sdk/chunked-blob-reader": "3.310.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/hash-node": {
-            "version": "3.344.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.344.0.tgz",
-            "integrity": "sha512-K0/mSvYR4hEfTRnnyoTj8ccqbXe2PpwvP4u8GXwk3Nr7s8qhDPYe8tFMv+6hoDJ50WJHrMTYGZ1HDAmjvP9uhA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+            "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-buffer-from": "3.310.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
@@ -687,11 +687,11 @@
             }
         },
         "node_modules/@aws-sdk/hash-stream-node": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.342.0.tgz",
-            "integrity": "sha512-8Ih3499SinJnuPAu1M7SBP5kF9zR8OsqD02VW8bO9jBpu1AYzs5k2OxTb86R+OWS6H+PJP6v1eTxNc9ZKUOhjg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.347.0.tgz",
+            "integrity": "sha512-tOBfcvELyt1GVuAlQ4d0mvm3QxoSSmvhH15SWIubM9RP4JWytBVzaFAn/aC02DBAWyvp0acMZ5J+47mxrWJElg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
             },
@@ -700,11 +700,11 @@
             }
         },
         "node_modules/@aws-sdk/invalid-dependency": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.342.0.tgz",
-            "integrity": "sha512-3qza2Br1jGKJi8toPYG9u5aGJ3sbGmJLgKDvlga7q3F8JaeB92He6muRJ07eyDvxZ9jiKhLZ2mtYoVcEjI7Mgw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+            "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             }
         },
@@ -720,22 +720,22 @@
             }
         },
         "node_modules/@aws-sdk/md5-js": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.342.0.tgz",
-            "integrity": "sha512-wtuvAgxz0DWfbXZyqzdkEXGYY1esEbgmjMj8gAoqomvbmiThOEisxNvHcCUJwgqs6vlPNP5pGBtgoHGF5J7JWA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.347.0.tgz",
+            "integrity": "sha512-mChE+7DByTY9H4cQ6fnWp2x5jf8e6OZN+AdLp6WQ+W99z35zBeqBxVmgm8ziJwkMIrkSTv9j3Y7T9Ve3RIcSfg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.342.0.tgz",
-            "integrity": "sha512-o6DNAmAt1MtCeg/mekcpIw/3Bcr9PAJM0Ogv3GUar2J8ziUDtaRGO0zm0YrQjsZf7E5+JLWMFL+OAeYeVV6QwA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.347.0.tgz",
+            "integrity": "sha512-i9n4ylkGmGvizVcTfN4L+oN10OCL2DKvyMa4cCAVE1TJrsnaE0g7IOOyJGUS8p5KJYQrKVR7kcsa2L1S0VeEcA==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-arn-parser": "3.310.0",
                 "@aws-sdk/util-config-provider": "3.310.0",
                 "tslib": "^2.5.0"
@@ -745,12 +745,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-content-length": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.342.0.tgz",
-            "integrity": "sha512-7LUMZqhihSAptGRFFQvuwt9nCLNzNPkGd1oU1RpVXw6YPQfKP9Ec5tgg4oUlv1t58IYQvdVj5ITKp4X2aUJVPg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+            "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -758,14 +758,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-endpoint": {
-            "version": "3.344.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.344.0.tgz",
-            "integrity": "sha512-rg4ysfusGw5tm8XTqNpdWo0wP0K79hZs3z1xkkskeSsMrbYiDn78Bkkt4s3JELUJY64VanQktPaKo08dNFYNZw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+            "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
             "dependencies": {
-                "@aws-sdk/middleware-serde": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/url-parser": "3.342.0",
-                "@aws-sdk/util-middleware": "3.342.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
+                "@aws-sdk/util-middleware": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -773,12 +773,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-expect-continue": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.342.0.tgz",
-            "integrity": "sha512-ohSZfseSJGECogtaXS/9VntGBALkJhfpsI7sK3cC20XcBlTI55rpy1AmD4vy0BEjEUQYBrkGuKKdmlT8DnjDRA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.347.0.tgz",
+            "integrity": "sha512-95M1unD1ENL0tx35dfyenSfx0QuXBSKtOi/qJja6LfX5771C5fm5ZTOrsrzPFJvRg/wj8pCOVWRZk+d5+jvfOQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -786,15 +786,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-flexible-checksums": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.342.0.tgz",
-            "integrity": "sha512-D68clBx5IHILCe4u8zxr0YRUHmQR6wf6pmLC9ddw7qWMgUU3Nr7AzzWebFO+VkoS5rX3KqQ0xCwzBUtYvixaNQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.347.0.tgz",
+            "integrity": "sha512-Pda7VMAIyeHw9nMp29rxdFft3EF4KP/tz/vLB6bqVoBNbLujo5rxn3SGOgStgIz7fuMLQQfoWIsmvxUm+Fp+Dw==",
             "dependencies": {
                 "@aws-crypto/crc32": "3.0.0",
                 "@aws-crypto/crc32c": "3.0.0",
                 "@aws-sdk/is-array-buffer": "3.310.0",
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
             },
@@ -803,12 +803,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.342.0.tgz",
-            "integrity": "sha512-EOoix2D2Mk3NQtv7UVhJttfttGYechQxKuGvCI8+8iEKxqlyXaKqAkLR07BQb6epMYeKP4z1PfJm203Sf0WPUQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+            "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -816,11 +816,11 @@
             }
         },
         "node_modules/@aws-sdk/middleware-location-constraint": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.342.0.tgz",
-            "integrity": "sha512-lakeKpMZreCc1nVTkVfkdl5SuojfKNL2oJvXVDDUFJ91sYx9FmhAT3++kWAun2SrU2S4TNXJ2SQL/8ON8TtSYQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.347.0.tgz",
+            "integrity": "sha512-x5fcEV7q8fQ0OmUO+cLhN5iPqGoLWtC3+aKHIfRRb2BpOO1khyc1FKzsIAdeQz2hfktq4j+WsrmcPvFKv51pSg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -828,11 +828,11 @@
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.342.0.tgz",
-            "integrity": "sha512-wbkp85T7p9sHLNPMY6HAXHvLOp+vOubFT/XLIGtgRhYu5aRJSlVo9qlwtdZjyhEgIRQ6H/QUnqAN7Zgk5bCLSw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+            "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -840,12 +840,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.342.0.tgz",
-            "integrity": "sha512-KUDseSAz95kXCqnXEQxNObpviZ6F7eJ5lEgpi+ZehlzGDk/GyOVgjVuAyI7nNxWI5v0ZJ5nIDy+BH273dWbnmQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+            "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -853,15 +853,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-retry": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.342.0.tgz",
-            "integrity": "sha512-Bfllrjqs0bXNG7A3ydLjTAE5zPEdigG+/lDuEsCfB35gywZnnxqi6BjTeQ9Ss6gbEWX+WyXP7/oVdNaUDQUr9Q==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
+            "integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/service-error-classification": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/util-middleware": "3.342.0",
-                "@aws-sdk/util-retry": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/service-error-classification": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-middleware": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
                 "tslib": "^2.5.0",
                 "uuid": "^8.3.2"
             },
@@ -870,12 +870,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.342.0.tgz",
-            "integrity": "sha512-fGZBmeSvOLKo4k/CSoa2v2TNdbw6eszGaFekOqHrIyfTW/a+VTcz+/MBLF9Cq1gayF1udjqjS+qbKB2ZiR31tA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.347.0.tgz",
+            "integrity": "sha512-TLr92+HMvamrhJJ0VDhA/PiUh4rTNQz38B9dB9ikohTaRgm+duP+mRiIv16tNPZPGl8v82Thn7Ogk2qPByNDtg==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-arn-parser": "3.310.0",
                 "tslib": "^2.5.0"
             },
@@ -884,12 +884,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-sts": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.342.0.tgz",
-            "integrity": "sha512-eGcGDC+6UWKC87mex3voBVRcZN3hzFN6GVzWkTS574hDqp/uJG3yPk3Dltw0qf8skikTGi3/ZE+yAxerq/f5rg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
+            "integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
             "dependencies": {
-                "@aws-sdk/middleware-signing": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -897,11 +897,11 @@
             }
         },
         "node_modules/@aws-sdk/middleware-serde": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.342.0.tgz",
-            "integrity": "sha512-WRD+Cyu6+h1ymfPnAw4fI2q3zXjihJ55HFe1uRF8VPN4uBbJNfN3IqL38y/SMEdZ0gH9zNlRNxZLhR0q6SNZEQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+            "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -909,15 +909,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.342.0.tgz",
-            "integrity": "sha512-CFRQyPv4OjRGmFoB3OfKcQ0aHgS9VWC0YwoHnSWIcLt3Xltorug/Amk0obr/MFoIrktdlVtmvLEJ4Z+8cdsz8g==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
+            "integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/signature-v4": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/util-middleware": "3.342.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/signature-v4": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-middleware": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -925,11 +925,11 @@
             }
         },
         "node_modules/@aws-sdk/middleware-ssec": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.342.0.tgz",
-            "integrity": "sha512-KLyxh082ITudpzlwtIEIq7VfBGpz/BdFafJOnO5h3TwJcIPsCml7XqLzbrjej8cPINRIqnXwMw8Pow/jC6drDg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.347.0.tgz",
+            "integrity": "sha512-467VEi2elPmUGcHAgTmzhguZ3lwTpwK+3s+pk312uZtVsS9rP1MAknYhpS3ZvssiqBUVPx8m29cLcC6Tx5nOJg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -937,9 +937,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-stack": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.342.0.tgz",
-            "integrity": "sha512-nDYtLAv9IZq8YFxtbyAiK/U1mtvtJS0DG6HiIPT5jpHcRpuWRHQ170EAW51zYts+21Ffj1VA6ZPkbup83+T6/w==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+            "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -948,13 +948,13 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.345.0.tgz",
-            "integrity": "sha512-e3auH6sqwyKCXCFNwRWYKkvWWxDHhyEnVWoYJEHqDwG6iWRwKqTBigIHao0sIrSEtZlewtE5pdeuTb0xoY19ZA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.347.0.tgz",
+            "integrity": "sha512-wJbGN3OE1/daVCrwk49whhIr9E0j1N4gWwN/wi4WuyYIA+5lMUfVp0aGIOvZR+878DxuFz2hQ4XcZVT4K2WvQw==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
-                "@aws-sdk/util-endpoints": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -962,13 +962,13 @@
             }
         },
         "node_modules/@aws-sdk/node-config-provider": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.342.0.tgz",
-            "integrity": "sha512-Mwkj4+zt64w7a8QDrI9q4SrEt7XRO30Vk0a0xENqcOGrKIPfF5aeqlw85NYLoGys+KV1oatqQ+k0GzKx8qTIdQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
+            "integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/shared-ini-file-loader": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -976,14 +976,14 @@
             }
         },
         "node_modules/@aws-sdk/node-http-handler": {
-            "version": "3.344.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.344.0.tgz",
-            "integrity": "sha512-04o5rrFBd8VzzN0Pcs7EEsyC6dz1maILbA6vdXrDvVLYqaO40Tpx2E/3KA/jZtOpHcGXxgDw2rv1kjJesoiEMw==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.348.0.tgz",
+            "integrity": "sha512-wxdgc4tO5F6lN4wHr0CZ4TyIjDW/ORp4SJZdWYNs2L5J7+/SwqgJY2lxRlGi0i7Md+apAdE3sT3ukVQ/9pVfPg==",
             "dependencies": {
-                "@aws-sdk/abort-controller": "3.342.0",
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/querystring-builder": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/abort-controller": "3.347.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/querystring-builder": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -991,11 +991,11 @@
             }
         },
         "node_modules/@aws-sdk/property-provider": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.342.0.tgz",
-            "integrity": "sha512-p4TR9yRakIpwupEH3BUijWMYThGG0q43n1ICcsBOcvWZpE636lIUw6nzFlOuBUwqyPfUyLbXzchvosYxfCl0jw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
+            "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1003,11 +1003,11 @@
             }
         },
         "node_modules/@aws-sdk/protocol-http": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.342.0.tgz",
-            "integrity": "sha512-zuF2urcTJBZ1tltPdTBQzRasuGB7+4Yfs9i5l0F7lE0luK5Azy6G+2r3WWENUNxFTYuP94GrrqaOhVyj8XXLPQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1015,11 +1015,11 @@
             }
         },
         "node_modules/@aws-sdk/querystring-builder": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.342.0.tgz",
-            "integrity": "sha512-tb3FbtC36a7XBYeupdKm60LeM0etp73I6/7pDAkzAlw7zJdvY0aQIvj1c0U6nZlwZF8sSSxC7vlamR+wCspdMw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+            "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-uri-escape": "3.310.0",
                 "tslib": "^2.5.0"
             },
@@ -1028,11 +1028,11 @@
             }
         },
         "node_modules/@aws-sdk/querystring-parser": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.342.0.tgz",
-            "integrity": "sha512-6svvr/LZW1EPJaARnOpjf92FIiK25wuO7fRq05gLTcTRAfUMDvub+oDg3Ro9EjJERumrYQrYCem5Qi4X9w8K2g==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+            "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1040,19 +1040,19 @@
             }
         },
         "node_modules/@aws-sdk/service-error-classification": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.342.0.tgz",
-            "integrity": "sha512-MwHO5McbdAVKxfQj1yhleboAXqrzcGoi9ODS+bwCwRfe2lakGzBBhu8zaGDlKYOdv5rS+yAPP/5fZZUiuZY8Bw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+            "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/shared-ini-file-loader": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.342.0.tgz",
-            "integrity": "sha512-kQG7TMQMhNp5+Y8vhGuO/+wU3K/dTx0xC0AKoDFiBf6EpDRmDfr2pPRnfJ9GwgS9haHxJ/3Uwc03swHMlsj20A==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
+            "integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1060,15 +1060,15 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.342.0.tgz",
-            "integrity": "sha512-OWrGO2UOa1ENpy0kYd2shK4sklQygWUqvWLx9FotDbjIeUIEfAnqoPq/QqcXVrNyT/UvPi4iIrjHJEO8JCNRmA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
+            "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
             "dependencies": {
-                "@aws-sdk/eventstream-codec": "3.342.0",
+                "@aws-sdk/eventstream-codec": "3.347.0",
                 "@aws-sdk/is-array-buffer": "3.310.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-middleware": "3.342.0",
+                "@aws-sdk/util-middleware": "3.347.0",
                 "@aws-sdk/util-uri-escape": "3.310.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
@@ -1078,13 +1078,13 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.344.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.344.0.tgz",
-            "integrity": "sha512-B5hN9b0Qa3UvpzsLjGIeCZ9AXE1qpwSXNXEeGcAdUIyf6lG3l+JMREKr+ZVaqAwAcZCOWmUyuuHIhkiK5YzClg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.347.0.tgz",
+            "integrity": "sha512-838h7pbRCVYWlTl8W+r5+Z5ld7uoBObgAn7/RB1MQ4JjlkfLdN7emiITG6ueVL+7gWZNZc/4dXR/FJSzCgrkxQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.342.0",
-                "@aws-sdk/signature-v4": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/signature-v4": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1100,12 +1100,12 @@
             }
         },
         "node_modules/@aws-sdk/smithy-client": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.342.0.tgz",
-            "integrity": "sha512-HQ4JejjHU2X7OAZPwixFG+EyPSjmoZqll7EvWjPSKyclWrM320haWWz1trVzjG/AgPfeDLfRkH/JoMr13lECew==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+            "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
             "dependencies": {
-                "@aws-sdk/middleware-stack": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1113,14 +1113,14 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.345.0.tgz",
-            "integrity": "sha512-Yhmc8j96LwFU3Fo6H2GYDTALZMGuuOw6PmYhjXa5kzgb9K7hfwiSn8hVyYTVenqkbyUdOuMI6BgXoIgZcdjFmA==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.348.0.tgz",
+            "integrity": "sha512-nTjoJkUsJUrJTZuqaeMD9PW2//Rdg2HgfDjiyC4jmAXtayWYCi11mqauurMaUHJ3p5qJ8f5xzxm6vBTbrftPag==",
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.345.0",
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/shared-ini-file-loader": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/client-sso-oidc": "3.348.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1128,9 +1128,9 @@
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.342.0.tgz",
-            "integrity": "sha512-5uyXVda/AgUpdZNJ9JPHxwyxr08miPiZ/CKSMcRdQVjcNnrdzY9m/iM9LvnQT44sQO+IEEkF2IoZIWvZcq199A==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1139,12 +1139,12 @@
             }
         },
         "node_modules/@aws-sdk/url-parser": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.342.0.tgz",
-            "integrity": "sha512-r4s/FDK6iywl8l4TqEwIwtNvxWO0kZes03c/yCiRYqxlkjVmbXEOodn5IAAweAeS9yqC3sl/wKbsaoBiGFn45g==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+            "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
             "dependencies": {
-                "@aws-sdk/querystring-parser": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/querystring-parser": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             }
         },
@@ -1214,12 +1214,12 @@
             }
         },
         "node_modules/@aws-sdk/util-defaults-mode-browser": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.342.0.tgz",
-            "integrity": "sha512-N1ZRvCLbrt4Re9MKU3pLYR0iO+H7GU7RsXG4yAq6DtSWT9WCw6xhIUpeV2T5uxWKL92o3WHNiGjwcebq+N73Bg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
+            "integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             },
@@ -1228,15 +1228,15 @@
             }
         },
         "node_modules/@aws-sdk/util-defaults-mode-node": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.342.0.tgz",
-            "integrity": "sha512-yNa/eX8sELnwM5NONOFR/PCJMHTNrUVklSo/QHy57CT/L3KOqosRNAMnDVMzH1QolGaVN/8jgtDI2xVsvlP+AA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
+            "integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
             "dependencies": {
-                "@aws-sdk/config-resolver": "3.342.0",
-                "@aws-sdk/credential-provider-imds": "3.342.0",
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/property-provider": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-imds": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1244,11 +1244,11 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.342.0.tgz",
-            "integrity": "sha512-ZsYF413hkVwSOjvZG6U0SshRtzSg6MtwzO+j90AjpaqgoHAxE5LjO5eVYFfPXTC2U8NhU7xkzASY6++e5bRRnw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.347.0.tgz",
+            "integrity": "sha512-/WUkirizeNAqwVj0zkcrqdQ9pUm1HY5kU+qy7xTR0OebkuJauglkmSTMD+56L1JPunWqHhlwCMVRaz5eaJdSEQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1278,9 +1278,9 @@
             }
         },
         "node_modules/@aws-sdk/util-middleware": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.342.0.tgz",
-            "integrity": "sha512-P2LYyMP4JUFZBy9DcMvCDxWU34mlShCyrqBZ1ouuGW7UMgRb1PTEvpLAVndIWn9H+1KGDFjMqOWp1FZHr4YZOA==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+            "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1289,11 +1289,11 @@
             }
         },
         "node_modules/@aws-sdk/util-retry": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.342.0.tgz",
-            "integrity": "sha512-U1LXXtOMAQjU4H9gjYZng8auRponAH0t3vShHMKT8UQggT6Hwz1obdXUZgcLCtcjp/1aEK4MkDwk2JSjuUTaZw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+            "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
             "dependencies": {
-                "@aws-sdk/service-error-classification": "3.342.0",
+                "@aws-sdk/service-error-classification": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1301,12 +1301,12 @@
             }
         },
         "node_modules/@aws-sdk/util-stream-browser": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.342.0.tgz",
-            "integrity": "sha512-9mPBlD2cfZmJiZoBmDxJ/FxXsMVoxB74v4aa83Nrk4RUlGGXj4GYcuwP6R0+F0d+1jfKARAwlBozL6I+/ICmoQ==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.347.0.tgz",
+            "integrity": "sha512-pIbmzIJfyX26qG622uIESOmJSMGuBkhmNU7I98bzhYCet5ctC0ow9L5FZw9ljOE46P/HkEcsOhh+qTHyCXlCEQ==",
             "dependencies": {
-                "@aws-sdk/fetch-http-handler": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-hex-encoding": "3.310.0",
                 "@aws-sdk/util-utf8": "3.310.0",
@@ -1314,12 +1314,12 @@
             }
         },
         "node_modules/@aws-sdk/util-stream-node": {
-            "version": "3.344.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.344.0.tgz",
-            "integrity": "sha512-Qn2CdmJyt6I+ofokNl5sa8GfKbuKTne5lw6DOhtGVUbqegyRmCx04Qkxy1fe++jdvf7zqb8V8I95lmlvnGYX1Q==",
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.348.0.tgz",
+            "integrity": "sha512-MFXyMUWA2oD0smBZf+sdnuyxLw8nCqyMEgYbos+6grvF1Szxn5+zbYTZrEBYiICqD1xJRLbWTzFLJU7oYm6pUg==",
             "dependencies": {
-                "@aws-sdk/node-http-handler": "3.344.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/types": "3.347.0",
                 "@aws-sdk/util-buffer-from": "3.310.0",
                 "tslib": "^2.5.0"
             },
@@ -1339,22 +1339,22 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.345.0.tgz",
-            "integrity": "sha512-q0mUueczB8yQlbGje/1am/seDYvbrMdLXzOfZkSWcY7f0kLWqsdOVb/PvfFnlr9VZYy9EwVfqIXMfchHPxSD5Q==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+            "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
             "dependencies": {
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/types": "3.347.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.345.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.345.0.tgz",
-            "integrity": "sha512-82N+/Td+QtEoM1j5tepsaIy64nMzgw1/qedE3pyLTFGfuQN7iVVppgS6lSvotX0kzWCgTCYyf9gTOMBOvEaVfg==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
+            "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
             "dependencies": {
-                "@aws-sdk/node-config-provider": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1390,12 +1390,12 @@
             }
         },
         "node_modules/@aws-sdk/util-waiter": {
-            "version": "3.342.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.342.0.tgz",
-            "integrity": "sha512-OkOdrvNW4fBPgYw022MLl2CfmnksSIOIoVvBjL042ksimwoc/pX8qofi4ZqnGrN+d0XifevL/+PMdIhJz4U+Sw==",
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.347.0.tgz",
+            "integrity": "sha512-3ze/0PkwkzUzLncukx93tZgGL0JX9NaP8DxTi6WzflnL/TEul5Z63PCruRNK0om17iZYAWKrf8q2mFoHYb4grA==",
             "dependencies": {
-                "@aws-sdk/abort-controller": "3.342.0",
-                "@aws-sdk/types": "3.342.0",
+                "@aws-sdk/abort-controller": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -2296,18 +2296,24 @@
             "dev": true
         },
         "node_modules/fast-xml-parser": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-            "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+            "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+            "funding": [
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
             "dependencies": {
                 "strnum": "^1.0.5"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
-            },
-            "funding": {
-                "type": "paypal",
-                "url": "https://paypal.me/naturalintelligence"
             }
         },
         "node_modules/fastq": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -103,7 +103,7 @@ functions:
     image:
       name: image
     name: IngestImage-${opt:stage, self:provider.stage, 'dev'}
-    reservedConcurrency: 30
+    reservedConcurrency: 100
     maximumRetryAttempts: 0
     timeout: 15
     events:

--- a/serverless.yml
+++ b/serverless.yml
@@ -103,6 +103,7 @@ functions:
     image:
       name: image
     name: IngestImage-${opt:stage, self:provider.stage, 'dev'}
+    reservedConcurrency: 30
     maximumRetryAttempts: 0
     timeout: 15
     events:


### PR DESCRIPTION
### Context

- Include the ByteSize of the image in the CreateImage request to allow the API to throw an error if the image size exceeds the current (4mb) limit of the serverless infra
- Standardize API calls via the `fetcher` function to keep the code a little simpler
- Conditionally attach unhandled errors to the created Image object (if it was created) 

Sibling PR: https://github.com/tnc-ca-geo/animl-api/pull/102