### PR TITLE
Error Handling for DateTimeOriginal

### DIFF
--- a/ingest-image/task.js
+++ b/ingest-image/task.js
@@ -291,7 +291,7 @@ export default class Task {
             md.DateTimeOriginal = this.convert_datetime_to_ISO(md.DateTimeOriginal);
         } catch (err) {
             console.warn(`not ok - could not parse DateTimeOriginal: ${md.DateTimeOriginal}: ${err.message}`);
-            md.DateTimeOriginal = 'unknown'
+            md.DateTimeOriginal = 'unknown';
         }
 
         md.MIMEType = md.MIMEType || mimetype || 'image/jpeg';

--- a/ingest-image/task.js
+++ b/ingest-image/task.js
@@ -286,7 +286,14 @@ export default class Task {
 
         const file_ext = path.parse(md.FileName).ext;
         md.FileTypeExtension = md.FileTypeExtension ? md.FileTypeExtension.toLowerCase() : file_ext;
-        md.DateTimeOriginal = this.convert_datetime_to_ISO(md.DateTimeOriginal);
+
+        try {
+            md.DateTimeOriginal = this.convert_datetime_to_ISO(md.DateTimeOriginal);
+        } catch (err) {
+            console.warn(`not ok - could not parse DateTimeOriginal: ${md.DateTimeOriginal}: ${err.message}`);
+            md.DateTimeOriginal = 'unknown'
+        }
+
         md.MIMEType = md.MIMEType || mimetype || 'image/jpeg';
         md.SerialNumber = md.SerialNumber || 'unknown';
         md.ArchiveBucket = this.ARCHIVE_BUCKET;


### PR DESCRIPTION
### Context

Set DateTimeOriginal to `unknown` when we can't parse it and avoid throwing an unrecoverable error.

A subsequent PR will be created against the API to accept these values and insert into the database alongside an ImageError.

Closes: https://github.com/tnc-ca-geo/animl-ingest/issues/58

cc/ @nathanielrindlaub 