### PR TITLE
More Logging

### DIFF
--- a/ingest-zip/index.js
+++ b/ingest-zip/index.js
@@ -238,6 +238,8 @@ async function fetcher(url, body) {
     });
 
     if (!res.ok) {
+        console.error('ERROR: Headers:', JSON.stringify(Object.fromEntries(res.headers)));
+
         const texterr = await res.text();
         let jsonerr;
         try {
@@ -246,6 +248,7 @@ async function fetcher(url, body) {
             throw new Error(texterr);
         }
 
+        console.error('ERROR: Body:', JSON.stringify(jsonerr));
         if (jsonerr.message) throw new Error(jsonerr.message);
         throw new Error(texterr);
     }

--- a/serverless.yml
+++ b/serverless.yml
@@ -281,6 +281,8 @@ resources:
           Environment:
             - Name: 'StackName'
               Value: !Ref "AWS::StackName"
+            - Name: 'STAGE'
+              Value: ${opt:stage, self:provider.stage, 'dev'}
             - Name: 'APIKEY'
               Value: '{{resolve:secretsmanager:api-key-${self:provider.stage}:SecretString:apikey}}'
           ResourceRequirements:


### PR DESCRIPTION
### Context

In an attempt to track down why batch uploads are not able to complete I need to be able to see more of the response object than is currently surfaced in the logs.

This PR introduces header logging and full body logging when a `fetcher` error occurs