### PR TITLE
Double Task Memory for larger images

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -294,7 +294,7 @@ resources:
             - Type: 'VCPU'
               Value: 1
             - Type: 'MEMORY'
-              Value: 2048
+              Value: 4096
           ExecutionRoleArn:
             Fn::GetAtt:
               - BatchExecRole


### PR DESCRIPTION
### Context

- A user recently uploaded images that are almost triple that of our average image size which caused the ingest task to fail due to being killed for excessive memory usage
- The images were indicative of a higher quality camera and as such should be supported
- This PR doubles the task memory to 4gb. 
- If we continue to see problems we can either increase the memory again or decrease internal concurrency (currently 1k images in parallel)
cc @nathanielrindlaub 