### PR TITLE
Expose ETAG in Cors

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -346,6 +346,7 @@ resources:
             - AllowedHeaders: [ "*" ]
               AllowedMethods: [ "PUT" ]
               AllowedOrigins: [ "*" ]
+              ExposedHeaders: ['ETag']
 
     # Bucket policy for animl-images-ingestion
     S3BucketPolicyAnimlImagesIngestionBucketPolicy:


### PR DESCRIPTION
### Context

XHR requests have limited access to header contents without being explicitly allowed via CORS.