### PR TITLE
fix: shorten callerreference value

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -482,7 +482,7 @@ resources:
       DependsOn: KeyGenerator
       Properties:
         PublicKeyConfig:
-          CallerReference: !Ref ${AWS::StackName}
+          CallerReference: !Ref AWS::StackName
           Comment: animl-images-serving-${opt:stage, self:provider.stage, 'dev'}
           EncodedKey: !GetAtt KeyGenerator.PublicKey
           Name: AnimlServiceKey-${opt:stage, self:provider.stage, 'dev'}

--- a/serverless.yml
+++ b/serverless.yml
@@ -482,7 +482,7 @@ resources:
       DependsOn: KeyGenerator
       Properties:
         PublicKeyConfig:
-          CallerReference: !Sub '${AWS::Region}-${AWS::AccountId}-${AWS::StackId}'
+          CallerReference: !Ref ${AWS::StackName}
           Comment: animl-images-serving-${opt:stage, self:provider.stage, 'dev'}
           EncodedKey: !GetAtt KeyGenerator.PublicKey
           Name: AnimlServiceKey-${opt:stage, self:provider.stage, 'dev'}


### PR DESCRIPTION
## What I'm Changing

When deploying to production, we received an error from CloudFormation when creating a `CloudFrontSigningPublicKey`:

```
Invalid request provided: AWS::CloudFront::PublicKey: The parameter CallerReference is too big. (Service: CloudFront, Status Code: 400, Request ID: 86f88058-6d61-4b38-809d-b62f9cc9837f) (SDK Attempt Count: 1)
```

This is due to the fact that in our code to create a CloudFrontSigningPublicKey we create a long composite value:

https://github.com/tnc-ca-geo/animl-ingest/blob/ef7fc9c416c7f82eee59f929213e19cfde05f69f/serverless.yml#L480-L488

Reviewing the docs[^1], we see that the `AWS::StackId` is an ARN of the CloudFormation stack:

> Returns the ID (ARN) of the stack, such as `arn:aws:cloudformation:us-west-2:123456789012:stack/teststack/51af3dc0-da77-11e4-872e-1234567db123`.

Appending this to the other values likely places us over character limits.  This PR shortens the `CallerReference` value

## How I Did It

The docs[^2] for a `CallerReference` describes as such:

> A string included in the request to help make sure that the request can't be replayed.

So the particular value of the string does not seem important, aside from it being unique per deployment (ie we wouldn't want two stacks to both be deploying and competing for the same `CallerReference` value).

Given this, I think we'd be fine by simply using the `AWS::StackName` value.

[^1]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-stackid

[^2]: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-cloudfront-publickey-publickeyconfig.html#cfn-cloudfront-publickey-publickeyconfig-callerreference